### PR TITLE
Add volunteer forms and interactive features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import RhizomeSyriaSubpage from './pages/RhizomeSyriaSubpage';
 import RhizomeCanadaSubpage from './pages/RhizomeCanadaSubpage';
 import ParticleSystem from './components/common/ParticleSystem';
 import CustomCursor from './components/common/CustomCursor';
+import LoadingScreen from './components/common/LoadingScreen';
 
 function App() {
   return (
@@ -23,6 +24,7 @@ function App() {
       <PhotoProvider>
         <Router>
           <div className="min-h-screen bg-gradient-to-br from-stone-50 to-emerald-50">
+            <LoadingScreen />
             <CustomCursor />
             <Navigation />
             <main>

--- a/src/components/common/CustomCursor.tsx
+++ b/src/components/common/CustomCursor.tsx
@@ -27,6 +27,24 @@ const CustomCursor: React.FC = () => {
     const handleMouseMove = (e: MouseEvent) => {
       mouseX.current = e.clientX;
       mouseY.current = e.clientY;
+
+      const wake = document.createElement('span');
+      wake.className = 'cursor-wake';
+      wake.style.left = `${e.clientX}px`;
+      wake.style.top = `${e.clientY}px`;
+      canvas.appendChild(wake);
+      setTimeout(() => wake.remove(), 600);
+
+      const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
+      if (el) {
+        const bg = window.getComputedStyle(el).backgroundColor;
+        const rgb = bg.match(/\d+/g);
+        if (rgb && rgb.length >= 3) {
+          const [r, g, b] = rgb.map(Number);
+          const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+          cursor.style.backgroundColor = brightness > 128 ? '#064e3b' : '#ffffff';
+        }
+      }
     };
 
     const handleMouseDown = () => {

--- a/src/components/common/LoadingScreen.tsx
+++ b/src/components/common/LoadingScreen.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+
+const LoadingScreen: React.FC = () => {
+  const [count, setCount] = useState(0);
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCount(c => {
+        if (c >= 100) {
+          clearInterval(interval);
+          document.body.classList.add('loaded');
+          setDone(true);
+          return 100;
+        }
+        return c + 1;
+      });
+    }, 20);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  if (done) return null;
+
+  return (
+    <div className="rhizome-loader">
+      <div className="counter">{count}%</div>
+    </div>
+  );
+};
+
+export default LoadingScreen;

--- a/src/components/common/SyriaParticleMap.tsx
+++ b/src/components/common/SyriaParticleMap.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+
+const SyriaParticleMap: React.FC = () => {
+  const mountRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!mountRef.current) return;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(
+      75,
+      mountRef.current.clientWidth / mountRef.current.clientHeight,
+      0.1,
+      1000
+    );
+    camera.position.z = 5;
+    const renderer = new THREE.WebGLRenderer({ alpha: true });
+    renderer.setSize(mountRef.current.clientWidth, mountRef.current.clientHeight);
+    mountRef.current.appendChild(renderer.domElement);
+
+    const particleCount = window.innerWidth < 768 ? 2000 : 5000;
+    const positions = new Float32Array(particleCount * 3);
+
+    for (let i = 0; i < particleCount; i++) {
+      positions[i * 3] = (Math.random() - 0.5) * 4;
+      positions[i * 3 + 1] = (Math.random() - 0.5) * 4;
+      positions[i * 3 + 2] = 0;
+    }
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    const material = new THREE.PointsMaterial({ color: 0xb91c1c, size: 0.02 });
+    const particles = new THREE.Points(geometry, material);
+    scene.add(particles);
+
+    const animate = () => {
+      requestAnimationFrame(animate);
+      particles.rotation.z += 0.001;
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    return () => {
+      renderer.dispose();
+      mountRef.current?.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  return <div ref={mountRef} style={{ width: '100%', height: '400px' }} />;
+};
+
+export default SyriaParticleMap;

--- a/src/components/common/VolunteerForms.tsx
+++ b/src/components/common/VolunteerForms.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+const VolunteerForms: React.FC = () => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    alert('Thank you for volunteering!');
+  };
+
+  return (
+    <div className="grid gap-8 md:grid-cols-2 mt-8">
+      <form
+        id="rcf-volunteer-form"
+        name="rcf-volunteer"
+        data-netlify="true"
+        onSubmit={handleSubmit}
+        className="space-y-4 bg-white p-6 rounded-xl shadow"
+      >
+        <h3 className="text-xl font-bold text-emerald-700">Volunteer with RCF</h3>
+        <input type="text" name="name" placeholder="Name" className="w-full border p-2 rounded" required />
+        <input type="email" name="email" placeholder="Email" className="w-full border p-2 rounded" required />
+        <textarea name="message" placeholder="Tell us about yourself" className="w-full border p-2 rounded" />
+        <button type="submit" className="px-4 py-2 bg-emerald-600 text-white rounded">Submit</button>
+      </form>
+      <form
+        id="rhizome-syria-form"
+        name="rhizome-syria-volunteer"
+        data-netlify="true"
+        dir="rtl"
+        onSubmit={handleSubmit}
+        className="space-y-4 bg-white p-6 rounded-xl shadow"
+      >
+        <h3 className="text-xl font-bold text-emerald-700">تطوع مع ريزوم سوريا</h3>
+        <input type="text" name="name" placeholder="الاسم" className="w-full border p-2 rounded text-right" required />
+        <input type="email" name="email" placeholder="البريد الإلكتروني" className="w-full border p-2 rounded text-right" required />
+        <textarea name="message" placeholder="حدثنا عن نفسك" className="w-full border p-2 rounded text-right" />
+        <button type="submit" className="px-4 py-2 bg-emerald-600 text-white rounded">إرسال</button>
+      </form>
+    </div>
+  );
+};
+
+export default VolunteerForms;

--- a/src/index.css
+++ b/src/index.css
@@ -63,6 +63,25 @@
   animation: rocket-ripple 0.6s ease-out;
 }
 
+.cursor-wake {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  background-color: #00a896;
+  border-radius: 50%;
+  pointer-events: none;
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0.4;
+  animation: wake-fade 0.6s ease-out;
+}
+
+@keyframes wake-fade {
+  to {
+    transform: translate(-50%, -50%) scale(3);
+    opacity: 0;
+  }
+}
+
 @keyframes rocket-ripple {
   to {
     transform: translate(-50%, -50%) scale(1.5, 0.4);
@@ -527,8 +546,28 @@ html {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
   }
-  
+
   #hypersonic-canvas {
     display: none !important;
   }
+}
+
+/* Loading Animation */
+.rhizome-loader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #0a1128;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.counter {
+  font-size: 5rem;
+  color: #ffffff;
+  font-weight: bold;
 }

--- a/src/pages/RhizomeSyriaPage.tsx
+++ b/src/pages/RhizomeSyriaPage.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { MapPin, Users, Target, Award, Calendar, Globe, Image, Palette, Heart, Shield, Star, Sparkles } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
+import SyriaParticleMap from '../components/common/SyriaParticleMap';
+import VolunteerForms from '../components/common/VolunteerForms';
 
 const RhizomeSyriaPage: React.FC = () => {
   const { t, currentLanguage } = useLanguage();
@@ -436,6 +438,13 @@ const RhizomeSyriaPage: React.FC = () => {
               </p>
             </div>
           </motion.div>
+        </div>
+      </section>
+
+      <section className="py-20 bg-white">
+        <div className="container mx-auto px-4">
+          <SyriaParticleMap />
+          <VolunteerForms />
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- add loader component with counter animation
- update custom cursor with wake effect and background contrast
- add new Syria particle map and bilingual volunteer forms
- wire components into Rhizome Syria page and main app
- style for wake effect and loader animation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a836aef4883239578cf9734910b48