### PR TITLE
Integrate Sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-intersection-observer": "^9.5.3",
     "react-leaflet": "^4.2.1",
     "react-router-dom": "^6.8.1",
+    "@sentry/react": "^7.104.0",
     "express": "^4.19.2",
     "axios": "^1.6.0",
     "cheerio": "^1.0.0-rc.12"

--- a/src/components/common/SentryTestButton.tsx
+++ b/src/components/common/SentryTestButton.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const SentryTestButton: React.FC = () => (
+  <button
+    type="button"
+    onClick={() => {
+      throw new Error('This is your first error!');
+    }}
+  >
+    Break the world
+  </button>
+);
+
+export default SentryTestButton;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import * as Sentry from '@sentry/react';
 import App from './App.tsx';
 import './index.css';
+
+Sentry.init({
+  dsn: 'https://81ccc90ca72193f24ec2ea5ef405d121@o4509617082269696.ingest.us.sentry.io/4509622411853824',
+  sendDefaultPii: true,
+});
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import ProgramsPreview from '../components/home/ProgramsPreview';
 import CommunityPreview from '../components/home/CommunityPreview';
 import ImpactStats from '../components/home/ImpactStats';
 import InteractiveMap from '../components/home/InteractiveMap';
+import SentryTestButton from '../components/common/SentryTestButton';
 
 const HomePage: React.FC = () => {
   return (
@@ -15,6 +16,7 @@ const HomePage: React.FC = () => {
       <InteractiveMap />
       <ImpactStats />
       <CommunityPreview />
+      <SentryTestButton />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add Sentry SDK dependency
- initialize Sentry early in the app lifecycle
- include a test button that throws an error for verification

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a9c512b6c8323aaa9e5f51658afec