### PR TITLE
Add Netlify headers configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository contains the source code for the Rhizome Community Foundation we
 
 ## Deployment Notes
 
-- The repository does not include Netlify-specific configuration files. To deploy on Netlify, create a new site pointing to this repository and enable SSL in the Netlify dashboard. If Netlify refuses to provision SSL, verify that your domain DNS records point to Netlify and that no conflicting certificates exist.
+- This repository now includes a `_headers` file that sets basic security headers processed by Netlify during deployment.
+- To deploy on Netlify, create a new site pointing to this repository and enable SSL in the Netlify dashboard. If Netlify refuses to provision SSL, verify that your domain DNS records point to Netlify and that no conflicting certificates exist.
 - The codebase does not currently integrate with Supabase or Neon. Any references to those services are likely from previous experiments or external configurations not present in this repository.
 

--- a/_headers
+++ b/_headers
@@ -1,0 +1,4 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+


### PR DESCRIPTION
## Summary
- add `_headers` file with security header rules for Netlify
- document the new header configuration in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686aa87b8a0483238235e789502f14f3