### PR TITLE
Update network map and cursor

### DIFF
--- a/src/components/common/CustomCursor.tsx
+++ b/src/components/common/CustomCursor.tsx
@@ -42,7 +42,9 @@ const CustomCursor: React.FC = () => {
         if (rgb && rgb.length >= 3) {
           const [r, g, b] = rgb.map(Number);
           const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-          cursor.style.backgroundColor = brightness > 128 ? '#064e3b' : '#ffffff';
+          const color = brightness > 128 ? '#064e3b' : '#ffffff';
+          cursor.style.backgroundColor = color;
+          follower.style.borderColor = color;
         }
       }
     };
@@ -64,16 +66,16 @@ const CustomCursor: React.FC = () => {
       // Main cursor - faster follow
       const dx = mouseX.current - cursorX.current;
       const dy = mouseY.current - cursorY.current;
-      cursorX.current += dx * 0.3;
-      cursorY.current += dy * 0.3;
+      cursorX.current += dx * 0.35;
+      cursorY.current += dy * 0.35;
       cursor.style.left = cursorX.current + 'px';
       cursor.style.top = cursorY.current + 'px';
 
       // Follower - slower follow
       const fdx = mouseX.current - followerX.current;
       const fdy = mouseY.current - followerY.current;
-      followerX.current += fdx * 0.15;
-      followerY.current += fdy * 0.15;
+      followerX.current += fdx * 0.1;
+      followerY.current += fdy * 0.1;
       follower.style.left = followerX.current + 'px';
       follower.style.top = followerY.current + 'px';
 

--- a/src/components/home/InteractiveMap.tsx
+++ b/src/components/home/InteractiveMap.tsx
@@ -1,79 +1,149 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
-import { MapPin, Users, Calendar } from 'lucide-react';
+import { MapPin, Calendar } from 'lucide-react';
 import { useLanguage } from '../../contexts/LanguageContext';
 
-interface Project {
+interface MapItem {
   id: string;
   lat: number;
   lng: number;
   name: string;
   nameAr: string;
-  city: string;
-  cityAr: string;
   description: string;
   descriptionAr: string;
-  participants: number;
-  startDate: string;
+  date?: string;
 }
 
 const InteractiveMap: React.FC = () => {
   const mapRef = useRef<HTMLDivElement>(null);
-  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+  const [selectedItem, setSelectedItem] = useState<MapItem | null>(null);
   const { t, currentLanguage } = useLanguage();
 
-  const projects: Project[] = [
+  const cities: MapItem[] = [
     {
-      id: '1',
-      lat: 33.5138,
-      lng: 36.2765,
-      name: 'Digital Literacy Workshop',
-      nameAr: 'ورشة محو الأمية الرقمية',
-      city: 'Damascus',
-      cityAr: 'دمشق',
-      description: 'Empowering communities through digital skills and technology education.',
-      descriptionAr: 'تمكين المجتمعات من خلال المهارات الرقمية والتعليم التقني.',
-      participants: 85,
-      startDate: '2024-01-15'
+      id: 'latakia',
+      lat: 35.5311,
+      lng: 35.7796,
+      name: 'Latakia (HQ)',
+      nameAr: 'اللاذقية (المقر الرئيسي)',
+      description: 'Headquarters of Rhizome Syria',
+      descriptionAr: 'المقر الرئيسي لريزوم سوريا'
     },
     {
-      id: '2',
+      id: 'aleppo',
       lat: 36.2021,
       lng: 37.1343,
-      name: 'Community Garden Initiative',
-      nameAr: 'مبادرة الحديقة المجتمعية',
-      city: 'Aleppo',
-      cityAr: 'حلب',
-      description: 'Creating sustainable food systems and social spaces in urban areas.',
-      descriptionAr: 'إنشاء أنظمة غذائية مستدامة ومساحات اجتماعية في المناطق الحضرية.',
-      participants: 120,
-      startDate: '2023-11-01'
+      name: 'Aleppo',
+      nameAr: 'حلب',
+      description: 'Aleppo Roots, Crystal Media, Masraha, Syrian Sect, Dawen',
+      descriptionAr: 'جذور حلب، كريستال ميديا، مسرحة، السوريان سكت، دوّن'
     },
     {
-      id: '3',
-      lat: 34.7478,
-      lng: 36.7259,
-      name: 'Oral History Archive',
-      nameAr: 'أرشيف التاريخ الشفوي',
-      city: 'Homs',
-      cityAr: 'حمص',
-      description: 'Preserving community stories and cultural heritage through digital documentation.',
-      descriptionAr: 'الحفاظ على قصص المجتمع والتراث الثقافي من خلال التوثيق الرقمي.',
-      participants: 65,
-      startDate: '2024-02-01'
+      id: 'izazz',
+      lat: 36.5861,
+      lng: 37.0462,
+      name: 'Izazz',
+      nameAr: 'إعزاز',
+      description: 'Anamel Baidaa',
+      descriptionAr: 'أنامل بيضاء'
     },
     {
-      id: '4',
-      lat: 35.5201,
-      lng: 35.793,
-      name: 'Youth Arts Program',
-      nameAr: 'برنامج الفنون الشبابية',
-      city: 'Latakia',
-      cityAr: 'اللاذقية',
-      description: 'Supporting young artists and creative expression in coastal communities.',
-      descriptionAr: 'دعم الفنانين الشباب والتعبير الإبداعي في المجتمعات الساحلية.',
-      participants: 45,
-      startDate: '2024-03-01'
+      id: 'homs',
+      lat: 34.7300,
+      lng: 36.7200,
+      name: 'Homs',
+      nameAr: 'حمص',
+      description: 'Syrian Youth Compass',
+      descriptionAr: 'بوصلة الشباب السوري'
+    },
+    {
+      id: 'salamiah',
+      lat: 35.0110,
+      lng: 37.0533,
+      name: 'Salamiah',
+      nameAr: 'سلمية',
+      description: 'Amal Organization, New Horizon',
+      descriptionAr: 'منظمة أمل، آفاق جديدة'
+    },
+    {
+      id: 'damascus',
+      lat: 33.5138,
+      lng: 36.2765,
+      name: 'Damascus',
+      nameAr: 'دمشق',
+      description: 'Mini TV, Dopamine',
+      descriptionAr: 'ميني تي في، دوبامين'
+    }
+  ];
+
+  const events: MapItem[] = [
+    {
+      id: 'rural-engagement',
+      lat: 35.5311,
+      lng: 35.7796,
+      name: 'Rural Engagement',
+      nameAr: 'المشاركة الريفية',
+      description: 'Ongoing rural engagement in Latakia',
+      descriptionAr: 'المشاركة الريفية الجارية في اللاذقية'
+    },
+    {
+      id: 'aleppo-roots-event',
+      lat: 36.2021,
+      lng: 37.1443,
+      name: 'Aleppo Roots Event',
+      nameAr: 'فعالية جذور حلب',
+      description: 'Aleppo Roots - March 15 2025',
+      descriptionAr: 'جذور حلب - 15 مارس 2025',
+      date: '2025-03-15'
+    },
+    {
+      id: 'castle-eid',
+      lat: 36.2121,
+      lng: 37.1343,
+      name: 'Castle Eid Activity',
+      nameAr: 'فعالية عيد القلعة',
+      description: 'Castle Eid Activity - June 10 2025',
+      descriptionAr: 'فعالية عيد القلعة - 10 حزيران 2025',
+      date: '2025-06-10'
+    }
+  ];
+
+  const towns: { id: string; lat: number; lng: number }[] = [
+    { id: 'qanjarah', lat: 35.627, lng: 35.915 },
+    { id: 'jannata', lat: 35.63, lng: 35.92 },
+    { id: 'kirsana', lat: 35.58, lng: 35.95 },
+    { id: 'kharbet', lat: 35.69, lng: 36.02 },
+    { id: 'mashqita', lat: 35.72, lng: 36.02 },
+    { id: 'ainbayda', lat: 35.62, lng: 35.92 },
+    { id: 'rasbasit', lat: 35.92, lng: 35.98 },
+    { id: 'qardaha', lat: 35.55, lng: 36.02 },
+    { id: 'bahloulieh', lat: 35.85, lng: 35.97 },
+    { id: 'haffa', lat: 35.74, lng: 36.1 },
+    { id: 'qutailibiyah', lat: 35.42, lng: 35.95 },
+    { id: 'beityashout', lat: 35.25, lng: 36.0 },
+    { id: 'muzayra', lat: 35.63, lng: 36.02 },
+    { id: 'qalaya', lat: 35.84, lng: 36.14 },
+    { id: 'qadmus', lat: 34.9, lng: 36.0 },
+    { id: 'safita', lat: 34.82, lng: 36.15 },
+    { id: 'dreikish', lat: 35.05, lng: 36.13 },
+    { id: 'masyaf', lat: 35.06, lng: 36.29 },
+    { id: 'deirmama', lat: 35.07, lng: 36.28 },
+    { id: 'baiyadiya', lat: 35.1, lng: 36.26 },
+    { id: 'mashteh', lat: 34.96, lng: 36.1 },
+    { id: 'sqilbieh', lat: 35.37, lng: 36.39 },
+    { id: 'sheikhbadr', lat: 34.96, lng: 36.05 },
+    { id: 'khreibat', lat: 34.9, lng: 35.97 }
+  ];
+
+  const globalNodes: MapItem[] = [
+    {
+      id: 'edmonton',
+      lat: 53.5461,
+      lng: -113.4938,
+      name: 'Edmonton',
+      nameAr: 'إدمونتون',
+      description: 'CO*LAB, RE:VITA, HQ',
+      descriptionAr: 'CO*LAB، RE:VITA، المقر'
     }
   ];
 
@@ -105,11 +175,54 @@ const InteractiveMap: React.FC = () => {
           iconAnchor: [7, 7]
         });
 
-        projects.forEach(project => {
-          const marker = L.marker([project.lat, project.lng], { icon: customIcon })
-            .addTo(map)
-            .on('click', () => setSelectedProject(project));
+        const eventIcon = L.divIcon({
+          className: 'custom-div-icon',
+          html: `<div style="background-color: #164e63; width: 12px; height: 12px; border-radius: 50%; border: 2px solid white;"></div>`,
+          iconSize: [15, 15],
+          iconAnchor: [7, 7]
         });
+
+        const townIcon = L.divIcon({
+          className: 'custom-div-icon',
+          html: `<div style="background-color: #15803d; width: 8px; height: 8px; border-radius: 50%; border: 1px solid white;"></div>`,
+          iconSize: [10, 10],
+          iconAnchor: [5, 5]
+        });
+
+        cities.forEach(item => {
+          const marker = L.marker([item.lat, item.lng], { icon: customIcon })
+            .addTo(map)
+            .on('click', () => setSelectedItem(item));
+        });
+
+        events.forEach(item => {
+          const marker = L.marker([item.lat, item.lng], { icon: eventIcon })
+            .addTo(map)
+            .on('click', () => setSelectedItem(item));
+        });
+
+        const townMarkers = towns.map(t =>
+          L.marker([t.lat, t.lng], { icon: townIcon })
+        );
+
+        const edmontonMarker = L.marker([53.5461, -113.4938], { icon: customIcon });
+
+        const updateVisibility = () => {
+          if (map.getZoom() >= 8) {
+            townMarkers.forEach(m => m.addTo(map));
+          } else {
+            townMarkers.forEach(m => map.removeLayer(m));
+          }
+
+          if (map.getZoom() <= 4) {
+            edmontonMarker.addTo(map).on('click', () => setSelectedItem(globalNodes[0]));
+          } else {
+            map.removeLayer(edmontonMarker);
+          }
+        };
+
+        updateVisibility();
+        map.on('zoomend', updateVisibility);
 
         // Add custom styles to the map
         const mapContainer = mapRef.current;
@@ -120,6 +233,7 @@ const InteractiveMap: React.FC = () => {
         }
 
         return () => {
+          map.off('zoomend', updateVisibility);
           map.remove();
         };
       }
@@ -168,49 +282,34 @@ const InteractiveMap: React.FC = () => {
             transition={{ duration: 0.8 }}
             className="space-y-6"
           >
-            {selectedProject ? (
+            {selectedItem ? (
               <div className="bg-white rounded-xl p-6 shadow-lg border border-emerald-100">
                 <h3 className={`text-xl font-semibold mb-4 text-emerald-700 ${
                   currentLanguage.code === 'ar' ? 'font-arabic' : ''
                 }`}>
-                  {t('project-name', selectedProject.name, selectedProject.nameAr)}
+                  {t('project-name', selectedItem.name, selectedItem.nameAr)}
                 </h3>
-                <p className={`text-gray-600 mb-6 ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}>
-                  {t('project-description', selectedProject.description, selectedProject.descriptionAr)}
+                <p className={`text-gray-600 mb-4 ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}>
+                  {t('project-description', selectedItem.description, selectedItem.descriptionAr)}
                 </p>
-                
-                <div className="grid grid-cols-3 gap-4">
-                  <div className="text-center p-3 bg-emerald-50 rounded-lg">
-                    <MapPin className="h-5 w-5 text-emerald-600 mx-auto mb-1" />
-                    <span className={`text-sm font-medium ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}>
-                      {t('project-city', selectedProject.city, selectedProject.cityAr)}
-                    </span>
+                {selectedItem.date && (
+                  <div className="flex items-center text-sm text-gray-600">
+                    <Calendar className="h-4 w-4 text-emerald-600 mr-2" />
+                    <span>{new Date(selectedItem.date).toLocaleDateString()}</span>
                   </div>
-                  <div className="text-center p-3 bg-emerald-50 rounded-lg">
-                    <Users className="h-5 w-5 text-emerald-600 mx-auto mb-1" />
-                    <span className="text-sm font-medium">
-                      {selectedProject.participants} {t('participants', 'participants', 'مشارك')}
-                    </span>
-                  </div>
-                  <div className="text-center p-3 bg-emerald-50 rounded-lg">
-                    <Calendar className="h-5 w-5 text-emerald-600 mx-auto mb-1" />
-                    <span className="text-sm font-medium">
-                      {new Date(selectedProject.startDate).toLocaleDateString()}
-                    </span>
-                  </div>
-                </div>
+                )}
               </div>
             ) : (
               <div className="bg-white rounded-xl p-6 text-center border border-emerald-100 shadow-lg">
                 <MapPin className="h-12 w-12 text-emerald-600 mx-auto mb-4" />
                 <h3 className={`text-lg font-semibold mb-2 ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}>
-                  {t('select-project', 'Select a Project', 'اختر مشروعاً')}
+                  {t('select-project', 'Select a Location', 'اختر موقعاً')}
                 </h3>
                 <p className={`text-gray-600 ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}>
                   {t(
                     'click-marker',
-                    'Click on a marker to view project details',
-                    'انقر على علامة لعرض تفاصيل المشروع'
+                    'Click on a marker to view details',
+                    'انقر على علامة لعرض التفاصيل'
                   )}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- revamp InteractiveMap to highlight Rhizome Syria network cities and events
- add hidden coastal towns, Edmonton node and zoom-based visibility
- restore lagging follower cursor and make it adapt color for better contrast

## Testing
- `npm run build`
- `npm run lint` *(fails: 30 errors, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686ac6f485508323a272a50c469a236d