### PR TITLE
Add knowledge hub page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import ContactPage from './pages/ContactPage';
 import AdminApprovalPage from './pages/AdminApprovalPage';
 import RhizomeSyriaSubpage from './pages/RhizomeSyriaSubpage';
 import RhizomeCanadaSubpage from './pages/RhizomeCanadaSubpage';
+import KnowledgeHubPage from './pages/KnowledgeHubPage';
 import ParticleSystem from './components/common/ParticleSystem';
 import CustomCursor from './components/common/CustomCursor';
 import LoadingScreen from './components/common/LoadingScreen';
@@ -36,6 +37,7 @@ function App() {
                 <Route path="/community-wall" element={<CommunityWallPage />} />
                 <Route path="/calendar" element={<CalendarPage />} />
                 <Route path="/contact" element={<ContactPage />} />
+                <Route path="/knowledge-hub" element={<KnowledgeHubPage />} />
                 <Route path="/admin" element={<AdminApprovalPage />} />
                 <Route path="/rhizome-syria-subpage" element={<RhizomeSyriaSubpage />} />
                 <Route path="/rhizome-canada-subpage" element={<RhizomeCanadaSubpage />} />

--- a/src/components/home/AboutPreview.tsx
+++ b/src/components/home/AboutPreview.tsx
@@ -59,6 +59,13 @@ const AboutPreview: React.FC = () => {
               </span>
               <ArrowRight className="h-5 w-5 group-hover:translate-x-1 transition-transform" />
             </Link>
+
+            <Link
+              to="/knowledge-hub"
+              className="mt-4 inline-flex items-center px-6 py-3 bg-stone-200 text-stone-800 font-semibold rounded-lg hover:bg-stone-300 transition-all duration-300"
+            >
+              {t('browse-knowledge-hub', 'Browse Knowledge Hub', 'تصفح مركز المعرفة')}
+            </Link>
           </motion.div>
         </div>
       </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { Network, Mail, Phone, MapPin } from 'lucide-react';
 import { useLanguage } from '../../contexts/LanguageContext';
+import { Link } from 'react-router-dom';
 
 const Footer: React.FC = () => {
   const { t, currentLanguage } = useLanguage();
@@ -41,25 +42,24 @@ const Footer: React.FC = () => {
             <h4 className={`font-semibold ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}>
               {t('quick-links', 'Quick Links', 'روابط سريعة')}
             </h4>
-            <ul className="space-y-2">
+                        <ul className="space-y-2">
               {[
-                { key: 'about', en: 'About Us', ar: 'من نحن' },
-                { key: 'projects', en: 'Our Projects', ar: 'مشاريعنا' },
-                { key: 'community', en: 'Community', ar: 'المجتمع' },
-                { key: 'contact', en: 'Contact', ar: 'اتصل بنا' }
+                { key: 'about', path: '/about', en: 'About Us', ar: 'من نحن' },
+                { key: 'programs', path: '/programs', en: 'Programs', ar: 'البرامج' },
+                { key: 'knowledge', path: '/knowledge-hub', en: 'Knowledge Hub', ar: 'مركز المعرفة' },
+                { key: 'contact', path: '/contact', en: 'Contact', ar: 'اتصل بنا' }
               ].map((link) => (
                 <li key={link.key}>
-                  <a
-                    href="#"
-                    className={`text-gray-300 hover:text-white transition-colors ${
-                      currentLanguage.code === 'ar' ? 'font-arabic' : ''
-                    }`}
+                  <Link
+                    to={link.path}
+                    className={`text-gray-300 hover:text-white transition-colors ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}
                   >
                     {t(`footer-link-${link.key}`, link.en, link.ar)}
-                  </a>
+                  </Link>
                 </li>
               ))}
             </ul>
+
           </motion.div>
 
           <motion.div

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -29,6 +29,7 @@ const Navigation: React.FC = () => {
     { key: 'programs', path: '/programs', en: 'Programs', ar: 'البرامج' },
     { key: 'rhizome-syria', path: '/rhizome-syria', en: 'Rhizome Syria', ar: 'ريزوم سوريا' },
     { key: 'community-wall', path: '/community-wall', en: 'Wallfinity', ar: 'وولفينيتي' },
+    { key: 'knowledge', path: '/knowledge-hub', en: 'Knowledge Hub', ar: 'مركز المعرفة' },
     { key: 'calendar', path: '/calendar', en: 'Calendar', ar: 'التقويم' },
     { key: 'contact', path: '/contact', en: 'Contact', ar: 'اتصل بنا' }
   ];

--- a/src/pages/KnowledgeHubPage.tsx
+++ b/src/pages/KnowledgeHubPage.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { BookOpen, ArrowRight } from 'lucide-react';
+import { useLanguage } from '../contexts/LanguageContext';
+import { Link } from 'react-router-dom';
+
+const KnowledgeHubPage: React.FC = () => {
+  const { t, currentLanguage } = useLanguage();
+
+  return (
+    <div className="pt-16 min-h-screen bg-gradient-to-br from-stone-50 to-emerald-50">
+      <section className="py-20 bg-gradient-to-r from-emerald-600 to-emerald-700 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <motion.h1
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            className="text-5xl font-bold mb-4"
+          >
+            {t('knowledge-hub-title', 'Knowledge Hub', 'مركز المعرفة')}
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, delay: 0.2 }}
+            className="text-xl text-emerald-100 max-w-3xl mx-auto"
+          >
+            {t(
+              'knowledge-hub-subtitle',
+              'Explore resources, case studies, and tools powering rhizomatic change across our network.',
+              'اكتشف الموارد ودراسات الحالة والأدوات التي تدعم التغيير الريزومي عبر شبكتنا.'
+            )}
+          </motion.p>
+        </div>
+      </section>
+
+      <section className="py-20 bg-white">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.8 }}
+            className={`text-center ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}
+          >
+            <BookOpen className="h-12 w-12 mx-auto text-emerald-600 mb-4" />
+            <p className="text-lg text-stone-700 mb-6">
+              {t(
+                'knowledge-hub-body',
+                'This evolving library begins with our foundational documents and will grow as the community adds new insights and translations.',
+                'تبدأ هذه المكتبة المتطورة بوثائقنا التأسيسية وستنمو مع إضافة المجتمع لرؤى وترجمات جديدة.'
+              )}
+            </p>
+            <Link
+              to="/contact"
+              className="inline-flex items-center px-6 py-3 bg-emerald-600 text-white font-semibold rounded-lg hover:bg-emerald-700 transition-colors"
+            >
+              <span className="mr-2">
+                {t('contribute-resource', 'Contribute a Resource', 'ساهم بمورد')}
+              </span>
+              <ArrowRight className="h-5 w-5" />
+            </Link>
+          </motion.div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default KnowledgeHubPage;


### PR DESCRIPTION
## Summary
- create new `KnowledgeHubPage` with bilingual text
- add knowledge hub route and navigation link
- link to knowledge hub from Home/About preview section
- update footer quick links with new page

## Testing
- `npm install`
- `npm run lint` *(fails: cannot find @eslint/js / unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_686b8c485a5083238141f6d085912512