### PR TITLE
Add Codex setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Node dependencies using npm.
+# Prefer reproducible installs with npm ci if a lockfile is present.
+
+if [ -f package-lock.json ]; then
+  npm ci
+else
+  npm install
+fi

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This repository contains the source code for the Rhizome Community Foundation we
    ```
    Ensure you run this command in an environment with internet access so that packages like `@eslint/js` can be installed.
 
+   If you're using the Codex environment, you can run the helper script instead:
+   ```bash
+   bash .codex/setup.sh
+   ```
+
 2. **Start the development server**
    ```bash
    npm run dev


### PR DESCRIPTION
## Summary
- create `.codex/setup.sh` for installing npm dependencies
- update README with instructions to run the setup script

## Testing
- `bash .codex/setup.sh`
- `npm run lint` *(fails: Unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_686bc22144e88323b53d05b166ce9db7