### PR TITLE
Restore checkerboard cursor

### DIFF
--- a/src/components/common/HypersonicCursor.tsx
+++ b/src/components/common/HypersonicCursor.tsx
@@ -28,11 +28,11 @@ const HypersonicCursor: React.FC = () => {
     const camera = new THREE.OrthographicCamera(-0.5, 0.5, 0.5, -0.5, 0.1, 10);
     camera.position.z = 1;
 
-    // Render a background image instead of a temporary checkerboard
+    // Render a simple checkerboard as a placeholder background
     const geometry = new THREE.PlaneGeometry(1, 1);
-    const textureLoader = new THREE.TextureLoader();
-    const backgroundTexture = textureLoader.load('/5-removebg-preview.png');
-    const material = new THREE.MeshBasicMaterial({ map: backgroundTexture });
+    const textureSize = 1024;
+    const checkerTexture = createCheckerboardTexture(textureSize, 16);
+    const material = new THREE.MeshBasicMaterial({ map: checkerTexture });
     const mesh = new THREE.Mesh(geometry, material);
     scene.add(mesh);
 
@@ -166,5 +166,24 @@ const HypersonicCursor: React.FC = () => {
 
   return <canvas ref={canvasRef} id="hypersonic-canvas" />;
 };
+
+function createCheckerboardTexture(size: number, checkerSize: number) {
+  const data = new Uint8Array(size * size * 4);
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const i = (y * size + x) * 4;
+      const isChecker =
+        (Math.floor(x / checkerSize) + Math.floor(y / checkerSize)) % 2 === 0;
+      const color = isChecker ? 255 : 0;
+      data[i] = color;
+      data[i + 1] = color;
+      data[i + 2] = color;
+      data[i + 3] = 255;
+    }
+  }
+  const texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
+  texture.needsUpdate = true;
+  return texture;
+}
 
 export default HypersonicCursor;


### PR DESCRIPTION
## Summary
- replace background image with checkerboard texture in `HypersonicCursor`
- add utility to generate checkerboard texture

The public logo image is still used by the navigation bar, so it remains in the project.

## Testing
- `npm run lint` *(fails: 30 errors, 6 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bfb61111483238dffc055584e2ecb