### PR TITLE
Remove Sentry test button from homepage

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -5,9 +5,18 @@ import ProgramsPreview from '../components/home/ProgramsPreview';
 import CommunityPreview from '../components/home/CommunityPreview';
 import ImpactStats from '../components/home/ImpactStats';
 import InteractiveMap from '../components/home/InteractiveMap';
-import SentryTestButton from '../components/common/SentryTestButton';
 
 const HomePage: React.FC = () => {
+  const [DevButton, setDevButton] = React.useState<React.FC | null>(null);
+
+  React.useEffect(() => {
+    if (import.meta.env.DEV) {
+      import('../components/common/SentryTestButton').then((module) => {
+        setDevButton(() => module.default);
+      });
+    }
+  }, []);
+
   return (
     <div>
       <HeroSection />
@@ -16,7 +25,7 @@ const HomePage: React.FC = () => {
       <InteractiveMap />
       <ImpactStats />
       <CommunityPreview />
-      <SentryTestButton />
+      {DevButton && <DevButton />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove the SentryTestButton import from `HomePage`
- lazily load the test button only during development

## Testing
- `npm run lint` *(fails: 30 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c11c0b4808323bbec08a9f02f23cc