### PR TITLE
Fix HypersonicCursor blending

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -117,7 +117,6 @@
   height: 100vh;
   pointer-events: none;
   z-index: 9999;
-  mix-blend-mode: screen;
 }
 
 /* Base Styles */


### PR DESCRIPTION
## Summary
- remove blend mode from the `#hypersonic-canvas` rule so it doesn't affect page styles

## Testing
- `npm run lint` *(fails: 30 errors, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686c1a8a6dc083239c1bae18fbe13ba4