### PR TITLE
Fix washed out appearance by removing overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,8 @@ function App() {
     <LanguageProvider>
       <PhotoProvider>
         <Router>
-          <div className="min-h-screen bg-gradient-to-br from-stone-50 to-emerald-50">
+          {/* Use a solid light background instead of a washed-out gradient */}
+          <div className="min-h-screen bg-white text-gray-900">
             <LoadingScreen />
             <CustomCursor />
             <HypersonicCursor />

--- a/src/index.css
+++ b/src/index.css
@@ -59,7 +59,7 @@
   pointer-events: none;
   transform: translate(-50%, -50%) scale(0);
   border-radius: 50%;
-  mix-blend-mode: overlay;
+  /* Removing blend mode prevents a white haze from covering the page */
   animation: rocket-ripple 0.6s ease-out;
 }
 
@@ -100,8 +100,9 @@
   --primary-color: #064e3b;
   --secondary-color: #047857;
   --accent-color: #b91c1c;
-  --text-color: #1f2937;
-  --bg-color: #fafaf9;
+  /* Darker text and solid background for improved contrast */
+  --text-color: #1a1a1a;
+  --bg-color: #ffffff;
   --card-bg: #ffffff;
   --border-radius: 12px;
   --shadow: 0 4px 20px rgba(0, 0, 0, 0.08);


### PR DESCRIPTION
## Summary
- remove blend mode from cursor ripple
- set higher contrast theme colors
- use solid white background for the app container

## Testing
- `npm run lint` *(fails: 30 errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c1e89859c83238e4a3c686e276112