### PR TITLE
Integrate Knowledge Hub page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import ContactPage from './pages/ContactPage';
 import AdminApprovalPage from './pages/AdminApprovalPage';
 import RhizomeSyriaSubpage from './pages/RhizomeSyriaSubpage';
 import RhizomeCanadaSubpage from './pages/RhizomeCanadaSubpage';
+import KnowledgeHubPage from './pages/KnowledgeHubPage';
 import ParticleSystem from './components/common/ParticleSystem';
 import CustomCursor from './components/common/CustomCursor';
 import LoadingScreen from './components/common/LoadingScreen';
@@ -34,6 +35,7 @@ function App() {
                 <Route path="/programs" element={<ProgramsPage />} />
                 <Route path="/rhizome-syria" element={<RhizomeSyriaPage />} />
                 <Route path="/community-wall" element={<CommunityWallPage />} />
+                <Route path="/knowledge-hub" element={<KnowledgeHubPage />} />
                 <Route path="/calendar" element={<CalendarPage />} />
                 <Route path="/contact" element={<ContactPage />} />
                 <Route path="/admin" element={<AdminApprovalPage />} />

--- a/src/components/home/AboutPreview.tsx
+++ b/src/components/home/AboutPreview.tsx
@@ -61,7 +61,7 @@ const AboutPreview: React.FC = () => {
             </Link>
 
             <Link
-              to="/knowledge-hub/rhizomatic-organization.html"
+              to="/knowledge-hub"
               className="mt-4 inline-flex items-center px-6 py-3 bg-stone-200 text-stone-800 font-semibold rounded-lg hover:bg-stone-300 transition-all duration-300"
             >
               {t('browse-knowledge-hub', 'Browse Knowledge Hub', 'تصفح مركز المعرفة')}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -46,7 +46,7 @@ const Footer: React.FC = () => {
               {[
                 { key: 'about', path: '/about', en: 'About Us', ar: 'من نحن' },
                 { key: 'programs', path: '/programs', en: 'Programs', ar: 'البرامج' },
-                { key: 'knowledge', path: '/knowledge-hub/rhizomatic-organization.html', en: 'Knowledge Hub', ar: 'مركز المعرفة' },
+                { key: 'knowledge', path: '/knowledge-hub', en: 'Knowledge Hub', ar: 'مركز المعرفة' },
                 { key: 'contact', path: '/contact', en: 'Contact', ar: 'اتصل بنا' }
               ].map((link) => (
                 <li key={link.key}>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -29,7 +29,7 @@ const Navigation: React.FC = () => {
     { key: 'programs', path: '/programs', en: 'Programs', ar: 'البرامج' },
     { key: 'rhizome-syria', path: '/rhizome-syria', en: 'Rhizome Syria', ar: 'ريزوم سوريا' },
     { key: 'community-wall', path: '/community-wall', en: 'Wallfinity', ar: 'وولفينيتي' },
-    { key: 'knowledge', path: '/knowledge-hub/rhizomatic-organization.html', en: 'Knowledge Hub', ar: 'مركز المعرفة' },
+    { key: 'knowledge', path: '/knowledge-hub', en: 'Knowledge Hub', ar: 'مركز المعرفة' },
     { key: 'calendar', path: '/calendar', en: 'Calendar', ar: 'التقويم' },
     { key: 'contact', path: '/contact', en: 'Contact', ar: 'اتصل بنا' }
   ];

--- a/src/pages/KnowledgeHubPage.tsx
+++ b/src/pages/KnowledgeHubPage.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useRef } from 'react';
+
+const KnowledgeHubPage: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    fetch('/knowledge-hub/rhizomatic-organization.html')
+      .then((res) => res.text())
+      .then((html) => {
+        if (containerRef.current) {
+          const scriptRegex = /<script>([\s\S]*?)<\/script>/;
+          const match = html.match(scriptRegex);
+          const scriptContent = match ? match[1] : '';
+          const cleanedHtml = html.replace(scriptRegex, '');
+          containerRef.current.innerHTML = cleanedHtml;
+          if (scriptContent) {
+            const script = document.createElement('script');
+            script.textContent = scriptContent;
+            containerRef.current.appendChild(script);
+          }
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load Knowledge Hub page', err);
+      });
+  }, []);
+
+  return <div ref={containerRef} />;
+};
+
+export default KnowledgeHubPage;


### PR DESCRIPTION
## Summary
- integrate Knowledge Hub page with React router
- load HTML content dynamically so navigation and footer stay consistent
- update navigation, footer and About preview links

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d42a55aa08323bdb87ef5d9e1cb7a