### PR TITLE
Add admin upload and accurate photo counts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { LanguageProvider } from './contexts/LanguageContext';
 import { PhotoProvider } from './contexts/PhotoContext';
+import { UserProvider } from './contexts/UserContext';
 import Navigation from './components/layout/Navigation';
 import Footer from './components/layout/Footer';
 import HomePage from './pages/HomePage';
@@ -22,8 +23,9 @@ import LoadingScreen from './components/common/LoadingScreen';
 function App() {
   return (
     <LanguageProvider>
-      <PhotoProvider>
-        <Router>
+      <UserProvider>
+        <PhotoProvider>
+          <Router>
           <div className="min-h-screen bg-gradient-to-br from-stone-50 to-emerald-50">
             <LoadingScreen />
             <CustomCursor />
@@ -47,9 +49,9 @@ function App() {
             <ParticleSystem />
           </div>
         </Router>
-      </PhotoProvider>
+        </PhotoProvider>
+      </UserProvider>
     </LanguageProvider>
   );
 }
-
 export default App;

--- a/src/components/community/PhotoUploadModal.tsx
+++ b/src/components/community/PhotoUploadModal.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { X, Upload, Camera, MapPin, Tag, User } from 'lucide-react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { usePhoto } from '../../contexts/PhotoContext';
+import { useUser } from '../../contexts/UserContext';
 
 interface PhotoUploadModalProps {
   isOpen: boolean;
@@ -12,6 +13,7 @@ interface PhotoUploadModalProps {
 const PhotoUploadModal: React.FC<PhotoUploadModalProps> = ({ isOpen, onClose }) => {
   const { t, currentLanguage } = useLanguage();
   const { addPhoto } = usePhoto();
+  const { isAdmin } = useUser();
   const [formData, setFormData] = useState({
     title: '',
     titleAr: '',
@@ -60,9 +62,13 @@ const PhotoUploadModal: React.FC<PhotoUploadModalProps> = ({ isOpen, onClose }) 
       featured: false
     };
 
-    addPhoto(newPhoto);
+    addPhoto(newPhoto, isAdmin);
 
-    alert('Your photo has been submitted for admin approval.');
+    if (isAdmin) {
+      alert('Photo uploaded successfully.');
+    } else {
+      alert('Your photo has been submitted for admin approval.');
+    }
 
     // Reset form
     setFormData({

--- a/src/contexts/PhotoContext.tsx
+++ b/src/contexts/PhotoContext.tsx
@@ -20,7 +20,10 @@ interface PhotoContextType {
   photos: Photo[];
   uploadedCount: number;
   targetCount: number;
-  addPhoto: (photo: Omit<Photo, 'id' | 'uploadDate' | 'approved'>) => void;
+  addPhoto: (
+    photo: Omit<Photo, 'id' | 'uploadDate' | 'approved'>,
+    approved?: boolean
+  ) => void;
   approvePhoto: (id: string) => void;
   deletePhoto: (id: string) => void;
   pendingPhotos: Photo[];
@@ -244,15 +247,21 @@ export const PhotoProvider: React.FC<PhotoProviderProps> = ({ children }) => {
     }
   ]);
 
-  const targetCount = 50000;
-  const uploadedCount = photos.filter(p => p.approved).length + 1247; // Simulated existing count
+  // Total number of stories the community aims to collect
+  const targetCount = 5000;
 
-  const addPhoto = (photoData: Omit<Photo, 'id' | 'uploadDate' | 'approved'>) => {
+  // Count only the photos that have been approved
+  const uploadedCount = photos.filter(p => p.approved).length;
+
+  const addPhoto = (
+    photoData: Omit<Photo, 'id' | 'uploadDate' | 'approved'>,
+    approved = false
+  ) => {
     const newPhoto: Photo = {
       ...photoData,
       id: Date.now().toString(),
       uploadDate: new Date().toISOString(),
-      approved: false
+      approved
     };
     setPhotos(prev => [newPhoto, ...prev]);
   };

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface UserContextType {
+  isAdmin: boolean;
+  setIsAdmin: (value: boolean) => void;
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const useUser = () => {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+  return context;
+};
+
+interface UserProviderProps {
+  children: ReactNode;
+}
+
+export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  return (
+    <UserContext.Provider value={{ isAdmin, setIsAdmin }}>
+      {children}
+    </UserContext.Provider>
+  );
+};

--- a/src/pages/AdminApprovalPage.tsx
+++ b/src/pages/AdminApprovalPage.tsx
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { usePhoto } from '../contexts/PhotoContext';
-import { CheckCircle, XCircle } from 'lucide-react';
+import { useUser } from '../contexts/UserContext';
+import PhotoUploadModal from '../components/community/PhotoUploadModal';
+import { CheckCircle, XCircle, Upload } from 'lucide-react';
 
 const AdminApprovalPage: React.FC = () => {
   const { pendingPhotos, approvePhoto, deletePhoto } = usePhoto();
+  const { setIsAdmin } = useUser();
+  const [showUploadModal, setShowUploadModal] = useState(false);
+
+  useEffect(() => {
+    setIsAdmin(true);
+    return () => setIsAdmin(false);
+  }, [setIsAdmin]);
 
   return (
     <div className="min-h-screen pt-20 px-6">
-      <h1 className="text-2xl font-bold mb-6">Pending Photo Approvals</h1>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Pending Photo Approvals</h1>
+        <button
+          onClick={() => setShowUploadModal(true)}
+          className="flex items-center space-x-1 bg-emerald-600 text-white px-3 py-1 rounded"
+        >
+          <Upload className="h-4 w-4" />
+          <span>Add Photo</span>
+        </button>
+      </div>
       {pendingPhotos.length === 0 && (
         <p>No pending photos.</p>
       )}
@@ -38,6 +56,10 @@ const AdminApprovalPage: React.FC = () => {
           </div>
         ))}
       </div>
+      <PhotoUploadModal
+        isOpen={showUploadModal}
+        onClose={() => setShowUploadModal(false)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `UserContext` to track admin status
- update `PhotoContext` to count actual photos and support immediate approval
- enable admin uploads in `PhotoUploadModal`
- wrap app in new `UserProvider`
- allow admins to upload photos directly from admin page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d7db7eb748323ac8814a6b89a9537