### PR TITLE
Improve Syria page map

### DIFF
--- a/src/components/common/SyriaLeafletMap.tsx
+++ b/src/components/common/SyriaLeafletMap.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useRef } from 'react';
+import { syrianCities } from '../../data/syrian_cities';
+
+const SyriaLeafletMap: React.FC = () => {
+  const mapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!mapRef.current) return;
+    const L = (window as any).L;
+    if (!L) return;
+
+    const map = L.map(mapRef.current, {
+      zoomControl: true,
+      attributionControl: false,
+    }).setView([35, 38.5], 6);
+
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+      subdomains: 'abcd',
+      maxZoom: 9,
+    }).addTo(map);
+
+    const icon = L.divIcon({
+      className: 'custom-div-icon',
+      html: `<div style="background-color: #b91c1c; width: 8px; height: 8px; border-radius: 50%; border: 1px solid white;"></div>`,
+      iconSize: [10, 10],
+      iconAnchor: [5, 5],
+    });
+
+    syrianCities.forEach(city => {
+      L.marker([city.lat, city.lng], { icon }).addTo(map).bindPopup(city.name);
+    });
+
+    return () => {
+      map.remove();
+    };
+  }, []);
+
+  return <div ref={mapRef} style={{ height: '400px', width: '100%', maxWidth: '400px', margin: '0 auto' }} />;
+};
+
+export default SyriaLeafletMap;

--- a/src/pages/RhizomeSyriaPage.tsx
+++ b/src/pages/RhizomeSyriaPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { MapPin, Users, Target, Award, Calendar, Globe, Image, Palette, Heart, Shield, Star, Sparkles } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
-import SyrianCitiesMap from '../components/common/SyrianCitiesMap';
+import SyriaLeafletMap from '../components/common/SyriaLeafletMap';
 import VolunteerForms from '../components/common/VolunteerForms';
 
 const RhizomeSyriaPage: React.FC = () => {
@@ -449,7 +449,7 @@ const RhizomeSyriaPage: React.FC = () => {
 
       <section id="volunteer" className="py-20 bg-white">
         <div className="container mx-auto px-4">
-          <SyrianCitiesMap />
+          <SyriaLeafletMap />
           <VolunteerForms />
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add new `SyriaLeafletMap` component using Leaflet
- display the interactive map on Rhizome Syria page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f7dd16b9083239391ad3dcd5c2542