### PR TITLE
Simplify landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import ContactPage from './pages/ContactPage';
 import AdminApprovalPage from './pages/AdminApprovalPage';
 import RhizomeSyriaSubpage from './pages/RhizomeSyriaSubpage';
 import RhizomeCanadaSubpage from './pages/RhizomeCanadaSubpage';
+import ImpactPage from './pages/ImpactPage';
 import KnowledgeHubPage from './pages/KnowledgeHubPage';
 import ParticleSystem from './components/common/ParticleSystem';
 import CustomCursor from './components/common/CustomCursor';
@@ -39,6 +40,7 @@ function App() {
                 <Route path="/community-wall" element={<CommunityWallPage />} />
                 <Route path="/knowledge-hub" element={<KnowledgeHubPage />} />
                 <Route path="/calendar" element={<CalendarPage />} />
+                <Route path="/impact" element={<ImpactPage />} />
                 <Route path="/contact" element={<ContactPage />} />
                 <Route path="/admin" element={<AdminApprovalPage />} />
                 <Route path="/rhizome-syria-subpage" element={<RhizomeSyriaSubpage />} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { useLanguage } from '../../contexts/LanguageContext';
-Cross-Origin-Embedder-Policy: require-corp
 
 const Header: React.FC = () => {
   const { t, currentLanguage } = useLanguage();

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -29,6 +29,7 @@ const Navigation: React.FC = () => {
     { key: 'rhizome-syria', path: '/rhizome-syria', en: 'Rhizome Syria', ar: 'ريزوم سوريا' },
     { key: 'knowledge', path: '/knowledge-hub', en: 'Knowledge Hub', ar: 'مركز المعرفة' },
     { key: 'calendar', path: '/calendar', en: 'Calendar', ar: 'التقويم' },
+    { key: 'impact', path: '/impact', en: 'Impact', ar: 'الأثر' },
     { key: 'contact', path: '/contact', en: 'Contact', ar: 'اتصل بنا' }
   ];
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,9 +2,6 @@ import React from 'react';
 import HeroSection from '../components/home/HeroSection';
 import AboutPreview from '../components/home/AboutPreview';
 import ProgramsPreview from '../components/home/ProgramsPreview';
-import CommunityPreview from '../components/home/CommunityPreview';
-import ImpactStats from '../components/home/ImpactStats';
-import InteractiveMap from '../components/home/InteractiveMap';
 import SentryTestButton from '../components/common/SentryTestButton';
 
 const HomePage: React.FC = () => {
@@ -13,9 +10,6 @@ const HomePage: React.FC = () => {
       <HeroSection />
       <AboutPreview />
       <ProgramsPreview />
-      <InteractiveMap />
-      <ImpactStats />
-      <CommunityPreview />
       <SentryTestButton />
     </div>
   );

--- a/src/pages/ImpactPage.tsx
+++ b/src/pages/ImpactPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ImpactStats from '../components/home/ImpactStats';
+
+const ImpactPage: React.FC = () => (
+  <div className="pt-16">
+    <ImpactStats />
+  </div>
+);
+
+export default ImpactPage;


### PR DESCRIPTION
## Summary
- trim HomePage down to hero, about preview and program preview only
- add new Impact page for metrics
- update navigation and routing to include Impact page
- fix stray line in Header component

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687089bb8e8083238fce57ca13538cdf