### PR TITLE
Simplify landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import AdminApprovalPage from './pages/AdminApprovalPage';
 import RhizomeSyriaSubpage from './pages/RhizomeSyriaSubpage';
 import RhizomeCanadaSubpage from './pages/RhizomeCanadaSubpage';
 import KnowledgeHubPage from './pages/KnowledgeHubPage';
+import ImpactPage from './pages/ImpactPage';
+import MapPage from './pages/MapPage';
 import ParticleSystem from './components/common/ParticleSystem';
 import CustomCursor from './components/common/CustomCursor';
 import LoadingScreen from './components/common/LoadingScreen';
@@ -38,6 +40,8 @@ function App() {
                 <Route path="/rhizome-syria" element={<RhizomeSyriaPage />} />
                 <Route path="/community-wall" element={<CommunityWallPage />} />
                 <Route path="/knowledge-hub" element={<KnowledgeHubPage />} />
+                <Route path="/impact" element={<ImpactPage />} />
+                <Route path="/map" element={<MapPage />} />
                 <Route path="/calendar" element={<CalendarPage />} />
                 <Route path="/contact" element={<ContactPage />} />
                 <Route path="/admin" element={<AdminApprovalPage />} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { useLanguage } from '../../contexts/LanguageContext';
-Cross-Origin-Embedder-Policy: require-corp
 
 const Header: React.FC = () => {
   const { t, currentLanguage } = useLanguage();

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -26,6 +26,8 @@ const Navigation: React.FC = () => {
   const navItems = [
     { key: 'about', path: '/about', en: 'About', ar: 'من نحن' },
     { key: 'programs', path: '/programs', en: 'Programs', ar: 'البرامج' },
+    { key: 'impact', path: '/impact', en: 'Impact', ar: 'الأثر' },
+    { key: 'map', path: '/map', en: 'Map', ar: 'خريطة' },
     { key: 'rhizome-syria', path: '/rhizome-syria', en: 'Rhizome Syria', ar: 'ريزوم سوريا' },
     { key: 'knowledge', path: '/knowledge-hub', en: 'Knowledge Hub', ar: 'مركز المعرفة' },
     { key: 'calendar', path: '/calendar', en: 'Calendar', ar: 'التقويم' },

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,9 +3,7 @@ import HeroSection from '../components/home/HeroSection';
 import AboutPreview from '../components/home/AboutPreview';
 import ProgramsPreview from '../components/home/ProgramsPreview';
 import CommunityPreview from '../components/home/CommunityPreview';
-import ImpactStats from '../components/home/ImpactStats';
-import InteractiveMap from '../components/home/InteractiveMap';
-import SentryTestButton from '../components/common/SentryTestButton';
+// Landing page now focuses on key highlights only
 
 const HomePage: React.FC = () => {
   return (
@@ -13,10 +11,7 @@ const HomePage: React.FC = () => {
       <HeroSection />
       <AboutPreview />
       <ProgramsPreview />
-      <InteractiveMap />
-      <ImpactStats />
       <CommunityPreview />
-      <SentryTestButton />
     </div>
   );
 };

--- a/src/pages/ImpactPage.tsx
+++ b/src/pages/ImpactPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ImpactStats from '../components/home/ImpactStats';
+
+const ImpactPage: React.FC = () => (
+  <div className="pt-16">
+    <ImpactStats />
+  </div>
+);
+
+export default ImpactPage;

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import InteractiveMap from '../components/home/InteractiveMap';
+
+const MapPage: React.FC = () => (
+  <div className="pt-16">
+    <InteractiveMap />
+  </div>
+);
+
+export default MapPage;


### PR DESCRIPTION
## Summary
- trim HomePage to a few preview sections
- move impact stats and map into new dedicated pages
- add new routes and navigation links
- fix stray text in `Header.tsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687089bb8e8083238fce57ca13538cdf