### PR TITLE
Simplify landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import AdminApprovalPage from './pages/AdminApprovalPage';
 import RhizomeSyriaSubpage from './pages/RhizomeSyriaSubpage';
 import RhizomeCanadaSubpage from './pages/RhizomeCanadaSubpage';
 import KnowledgeHubPage from './pages/KnowledgeHubPage';
+import MapPage from './pages/MapPage';
+import ImpactPage from './pages/ImpactPage';
 import ParticleSystem from './components/common/ParticleSystem';
 import CustomCursor from './components/common/CustomCursor';
 import LoadingScreen from './components/common/LoadingScreen';
@@ -40,6 +42,8 @@ function App() {
                 <Route path="/knowledge-hub" element={<KnowledgeHubPage />} />
                 <Route path="/calendar" element={<CalendarPage />} />
                 <Route path="/contact" element={<ContactPage />} />
+                <Route path="/impact" element={<ImpactPage />} />
+                <Route path="/map" element={<MapPage />} />
                 <Route path="/admin" element={<AdminApprovalPage />} />
                 <Route path="/rhizome-syria-subpage" element={<RhizomeSyriaSubpage />} />
                 <Route path="/rhizome-canada-subpage" element={<RhizomeCanadaSubpage />} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { useLanguage } from '../../contexts/LanguageContext';
-Cross-Origin-Embedder-Policy: require-corp
 
 const Header: React.FC = () => {
   const { t, currentLanguage } = useLanguage();

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -26,6 +26,8 @@ const Navigation: React.FC = () => {
   const navItems = [
     { key: 'about', path: '/about', en: 'About', ar: 'من نحن' },
     { key: 'programs', path: '/programs', en: 'Programs', ar: 'البرامج' },
+    { key: 'impact', path: '/impact', en: 'Impact', ar: 'الأثر' },
+    { key: 'map', path: '/map', en: 'Map', ar: 'الخريطة' },
     { key: 'rhizome-syria', path: '/rhizome-syria', en: 'Rhizome Syria', ar: 'ريزوم سوريا' },
     { key: 'knowledge', path: '/knowledge-hub', en: 'Knowledge Hub', ar: 'مركز المعرفة' },
     { key: 'calendar', path: '/calendar', en: 'Calendar', ar: 'التقويم' },

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,21 +2,47 @@ import React from 'react';
 import HeroSection from '../components/home/HeroSection';
 import AboutPreview from '../components/home/AboutPreview';
 import ProgramsPreview from '../components/home/ProgramsPreview';
-import CommunityPreview from '../components/home/CommunityPreview';
-import ImpactStats from '../components/home/ImpactStats';
-import InteractiveMap from '../components/home/InteractiveMap';
-import SentryTestButton from '../components/common/SentryTestButton';
+import { Link } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const HomePage: React.FC = () => {
+  const { t } = useLanguage();
   return (
     <div>
       <HeroSection />
       <AboutPreview />
       <ProgramsPreview />
-      <InteractiveMap />
-      <ImpactStats />
-      <CommunityPreview />
-      <SentryTestButton />
+      <section className="py-12 bg-white">
+        <div className="max-w-7xl mx-auto px-4 text-center">
+          <h2 className="text-2xl font-bold text-stone-900 mb-6">
+            {t('explore-more', 'Explore More', 'استكشف المزيد')}
+          </h2>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link
+              to="/impact"
+              className="group inline-flex items-center px-6 py-3 bg-emerald-600 text-white font-semibold rounded-lg hover:bg-emerald-700 transition-colors"
+            >
+              <span className="mr-2">{t('our-impact', 'Our Impact', 'أثرنا')}</span>
+              <ArrowRight className="h-5 w-5 group-hover:translate-x-1 transition-transform" />
+            </Link>
+            <Link
+              to="/map"
+              className="group inline-flex items-center px-6 py-3 bg-emerald-600 text-white font-semibold rounded-lg hover:bg-emerald-700 transition-colors"
+            >
+              <span className="mr-2">{t('activities-map', 'Activities Map', 'خريطة الأنشطة')}</span>
+              <ArrowRight className="h-5 w-5 group-hover:translate-x-1 transition-transform" />
+            </Link>
+            <Link
+              to="/community-wall"
+              className="group inline-flex items-center px-6 py-3 bg-emerald-600 text-white font-semibold rounded-lg hover:bg-emerald-700 transition-colors"
+            >
+              <span className="mr-2">{t('community-wall', 'Community Wall', 'لوحة المجتمع')}</span>
+              <ArrowRight className="h-5 w-5 group-hover:translate-x-1 transition-transform" />
+            </Link>
+          </div>
+        </div>
+      </section>
     </div>
   );
 };

--- a/src/pages/ImpactPage.tsx
+++ b/src/pages/ImpactPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ImpactStats from '../components/home/ImpactStats';
+
+const ImpactPage: React.FC = () => (
+  <div className="min-h-screen bg-gradient-to-br from-stone-50 to-emerald-50 pt-16">
+    <ImpactStats />
+  </div>
+);
+
+export default ImpactPage;

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import InteractiveMap from '../components/home/InteractiveMap';
+
+const MapPage: React.FC = () => (
+  <div className="min-h-screen bg-gradient-to-br from-stone-50 to-emerald-50 pt-16">
+    <InteractiveMap />
+  </div>
+);
+
+export default MapPage;


### PR DESCRIPTION
## Summary
- simplify the landing page
- add new Impact and Map pages
- update routes and navigation
- clean invalid header metadata

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687089bb8e8083238fce57ca13538cdf