### PR TITLE
Simplify landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Rhizome Community Foundation - Community Network for Change</title>
-    <meta name="description" content="Building collaborative networks to strengthen civil society through community-led initiatives." />
+    <title>Rhizome Community Foundation - Cultivating Community-Led Solutions</title>
+    <meta name="description" content="Connect. Support. Transform. We empower communities to alleviate poverty, advance education, and promote health through local leadership." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Noto+Sans+Arabic:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/src/components/home/AboutPreview.tsx
+++ b/src/components/home/AboutPreview.tsx
@@ -50,11 +50,7 @@ const AboutPreview: React.FC = () => {
               )}
             </p>
 
-            <ul className="list-disc pl-5 text-stone-600 mb-6">
-              <li>{t('update-workshop', 'Network expansion workshop completed', 'اكتمل ورشة توسيع الشبكة')}</li>
-              <li>{t('update-publication', 'New research publication available', 'تقرير بحثي جديد متاح')}</li>
-              <li>{t('update-training', 'Partner organization training series launched', 'إطلاق سلسلة تدريب للشركاء')}</li>
-            </ul>
+            {/* Highlights moved to the About page for brevity */}
 
             <Link
               to="/about"

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -184,7 +184,7 @@ const HeroSection: React.FC = () => {
             transition={{ duration: 1.2, delay: 0.3 }}
             style={{ fontFamily: '"Playfair Display", "Noto Sans Arabic", serif' }}
           >
-            {t('hero-title', 'Rhizome Community Foundation', 'مؤسسة ريزوم المجتمعية')}
+            {t('hero-title', 'Cultivating Community-Led Solutions', 'زراعة حلول بقيادة المجتمع')}
           </motion.h1>
           
           <motion.p
@@ -195,8 +195,8 @@ const HeroSection: React.FC = () => {
           >
             {t(
               'hero-subtitle',
-              'Empowering communities in post-war regions through collaborative, community-led networks.',
-              'نُمكِّن المجتمعات في مناطق ما بعد الحرب عبر شبكات تعاونية تقودها المجتمعات.'
+              'At the Rhizome Community Foundation, we believe lasting change grows from the ground up. We support community-driven initiatives that alleviate poverty, advance education, and promote health.',
+              'في مؤسسة ريزوم المجتمعية، نؤمن بأن التغيير الدائم ينمو من الجذور. ندعم المبادرات المجتمعية التي تخفف الفقر وتعزز التعليم والصحة.'
             )}
           </motion.p>
           
@@ -207,11 +207,11 @@ const HeroSection: React.FC = () => {
             className="flex flex-col sm:flex-row gap-4 justify-center"
           >
             <Link
-              to="/programs"
+              to="/contact"
               className="group inline-flex items-center px-8 py-4 bg-emerald-600 text-white font-semibold rounded-full shadow-lg hover:bg-emerald-700 hover:shadow-xl transition-all duration-300 transform hover:scale-105"
             >
               <span className="mr-2">
-                {t('explore-programs', 'Discover Our Impact', 'اكتشف تأثيرنا')}
+                {t('explore-programs', 'Get Involved', 'شارك معنا')}
               </span>
               <ArrowRight className="h-5 w-5 group-hover:translate-x-1 transition-transform" />
             </Link>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { useLanguage } from '../../contexts/LanguageContext';
-Cross-Origin-Embedder-Policy: require-corp
 
 const Header: React.FC = () => {
   const { t, currentLanguage } = useLanguage();

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import HeroSection from '../components/home/HeroSection';
 import AboutPreview from '../components/home/AboutPreview';
 import ProgramsPreview from '../components/home/ProgramsPreview';
-import CommunityPreview from '../components/home/CommunityPreview';
-import ImpactStats from '../components/home/ImpactStats';
-import InteractiveMap from '../components/home/InteractiveMap';
-import SentryTestButton from '../components/common/SentryTestButton';
+// Landing page now focuses on a streamlined introduction. Detailed
+// content like maps, community walls, and stats were moved to
+// dedicated pages to keep the home concise.
 
 const HomePage: React.FC = () => {
   return (
@@ -13,10 +12,7 @@ const HomePage: React.FC = () => {
       <HeroSection />
       <AboutPreview />
       <ProgramsPreview />
-      <InteractiveMap />
-      <ImpactStats />
-      <CommunityPreview />
-      <SentryTestButton />
+      {/* Additional sections are now available on subpages. */}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- streamline home page so it only shows hero and previews
- update hero content and CTA
- trim about preview section
- remove stray header directive causing lint error
- change site tagline in `<title>` and meta description

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687089bb8e8083238fce57ca13538cdf