### PR TITLE
Update mission text and blank events

### DIFF
--- a/src/components/home/AboutPreview.tsx
+++ b/src/components/home/AboutPreview.tsx
@@ -45,8 +45,8 @@ const AboutPreview: React.FC = () => {
             <p className="text-lg text-stone-600 mb-8 leading-relaxed">
               {t(
                 'about-description',
-                'The Rhizome Community Foundation is a Canadian not-for-profit organization dedicated to amplifying the voices and agency of communities disproportionately affected by intersecting challenges. Our mission is to empower these communities to identify and drive their own priorities, fostering innovative, locally-led solutions that address their distinct and evolving needs.',
-                'مؤسسة مجتمع رايزوم هي منظمة غير ربحية كندية مكرسة لتعزيز صوت ووكالة المجتمعات المتأثرة بشكل غير متناسب بالتحديات المتقاطعة. رسالتنا هي تمكين هذه المجتمعات من تحديد أولوياتها وقيادتها بنفسها من خلال حلول مبتكرة محلية تستجيب لاحتياجاتها المميزة والمتطورة.'
+                'Founded in Edmonton in 2025, Rhizome Community Foundation empowers communities to shape their own futures. We cultivate networks that alleviate poverty, advance education, and promote health through grassroots leadership.',
+                'تأسست في إدمونتون عام 2025 لتمكين المجتمعات من تشكيل مستقبلها. نزرع شبكات تخفف الفقر وتعزز التعليم والصحة بقيادة المجتمعات المحلية.'
               )}
             </p>
 

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -184,7 +184,7 @@ const HeroSection: React.FC = () => {
             transition={{ duration: 1.2, delay: 0.3 }}
             style={{ fontFamily: '"Playfair Display", "Noto Sans Arabic", serif' }}
           >
-            {t('hero-title', 'Rhizome Community Foundation', 'مؤسسة ريزوم المجتمعية')}
+            {t('hero-title', 'Cultivating Community-Led Solutions', 'نزرع حلولاً بقيادة المجتمع')}
           </motion.h1>
           
           <motion.p
@@ -195,8 +195,8 @@ const HeroSection: React.FC = () => {
           >
             {t(
               'hero-subtitle',
-              'Empowering communities in post-war regions through collaborative, community-led networks.',
-              'نُمكِّن المجتمعات في مناطق ما بعد الحرب عبر شبكات تعاونية تقودها المجتمعات.'
+              'At the Rhizome Community Foundation, we believe true change grows from the ground up. We support community initiatives that alleviate poverty, advance education, and promote health through local wisdom.',
+              'في مؤسسة ريزوم المجتمعية نؤمن بأن التغيير الحقيقي ينمو من القاعدة. ندعم المبادرات المجتمعية التي تخفف الفقر وتعزز التعليم والصحة مستندين إلى المعرفة المحلية.'
             )}
           </motion.p>
           

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -75,7 +75,7 @@ const Footer: React.FC = () => {
             <div className="space-y-3">
               <div className="flex items-center space-x-3">
                 <Mail className="h-4 w-4 text-green-400" />
-                <span className="text-gray-300">info@rhizomecf.org</span>
+                <span className="text-gray-300">info@rhizomefoundation.ca</span>
               </div>
               <div className="flex items-center space-x-3">
                 <MapPin className="h-4 w-4 text-green-400" />

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -41,88 +41,17 @@ const CalendarPage: React.FC = () => {
     { key: 'general', en: 'General', ar: 'عام', color: 'bg-gray-500' }
   ];
 
-  const initialEvents: CalendarEvent[] = [
-    {
-      id: '1',
-      title: 'Digital Literacy Workshop',
-      titleAr: 'ورشة محو الأمية الرقمية',
-      category: 'workshop',
-      date: '2024-02-15',
-      time: '10:00 AM',
-      timeAr: '10:00 صباحاً',
-      duration: '3 hours',
-      durationAr: '3 ساعات',
-      location: 'Toronto Community Center',
-      locationAr: 'مركز تورونتو المجتمعي',
-      description: 'Learn essential digital skills for job searching and online communication.',
-      descriptionAr: 'تعلم المهارات الرقمية الأساسية للبحث عن عمل والتواصل عبر الإنترنت.',
-      attendees: 25,
-      maxAttendees: 30,
-      isOnline: false,
-      registrationRequired: true,
-      organizer: 'Rhizome Canada',
-      organizerAr: 'ريزوم كندا',
-      priority: 3
-    },
-    {
-      id: '2',
-      title: 'Syrian Heritage Storytelling Night',
-      titleAr: 'ليلة سرد التراث السوري',
-      category: 'cultural',
-      date: '2024-02-18',
-      time: '7:00 PM',
-      timeAr: '7:00 مساءً',
-      duration: '2 hours',
-      durationAr: 'ساعتان',
-      location: 'Virtual Event',
-      locationAr: 'فعالية افتراضية',
-      description: 'Share and listen to stories that preserve our cultural heritage.',
-      descriptionAr: 'شارك واستمع إلى القصص التي تحافظ على تراثنا الثقافي.',
-      attendees: 45,
-      maxAttendees: 100,
-      isOnline: true,
-      registrationRequired: true,
-      organizer: 'Cultural Preservation Team',
-      organizerAr: 'فريق الحفاظ على الثقافة',
-      priority: 2
-    }
-  ];
+  // Events are intentionally left blank for this experimental release
+  const initialEvents: CalendarEvent[] = [];
 
   useEffect(() => {
     fetchEvents();
   }, []);
 
   const fetchEvents = async () => {
-    setLoading(true);
-    setError(null);
-    
-    try {
-      const response = await fetch('/api/events');
-      
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      
-      const data = await response.json();
-      
-      if (data.events) {
-        // Merge scraped events with initial events
-        const allEvents = [...initialEvents, ...data.events];
-        setEvents(allEvents);
-        setLastUpdated(data.metadata?.lastUpdated || new Date().toISOString());
-      } else {
-        // Fallback to just scraped events if no metadata
-        const scrapedEvents = Array.isArray(data) ? data : [];
-        setEvents([...initialEvents, ...scrapedEvents]);
-        setLastUpdated(new Date().toISOString());
-      }
-    } catch (err) {
-      console.error('Failed to fetch calendar events:', err);
-      setError('Failed to load live events. Showing sample events.');
-      setEvents(initialEvents); // Fallback to initial events
-    } finally {
-      setLoading(false);
-    }
+    // In this experimental release we do not load live events
+    setLoading(false);
+    setEvents(initialEvents);
   };
 
   const filteredEvents = selectedCategory === 'all' 


### PR DESCRIPTION
## Summary
- refresh homepage mission statement
- clarify about page text
- update footer email address
- clear sample events and disable fetching in calendar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870e579b1bc83239890d31f91100606