### PR TITLE
Add robust scraping infrastructure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@sentry/node": "^7.120.0",
         "@sentry/react": "^7.120.0",
         "axios": "^1.7.2",
+        "axios-retry": "^4.5.0",
         "bull": "^4.16.5",
         "cheerio": "^1.0.0",
         "d3": "^7.9.0",
@@ -4715,6 +4716,18 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/axios-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -8351,6 +8364,18 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@sentry/node": "^7.120.0",
     "@sentry/react": "^7.120.0",
     "axios": "^1.7.2",
+    "axios-retry": "^4.5.0",
     "bull": "^4.16.5",
     "cheerio": "^1.0.0",
     "d3": "^7.9.0",

--- a/server/db/cache.ts
+++ b/server/db/cache.ts
@@ -1,17 +1,41 @@
 import Redis from 'ioredis';
-
-const redis = new Redis({
-  host: process.env.REDIS_HOST || 'localhost',
-  port: Number(process.env.REDIS_PORT) || 6379
-});
+import { Event } from '../types/event';
 
 export class EventCache {
-  static async get(key: string) {
-    const data = await redis.get(key);
-    return data ? JSON.parse(data) : null;
+  private redis: Redis;
+  private TTL = 3600; // 1 hour
+
+  constructor() {
+    this.redis = new Redis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: parseInt(process.env.REDIS_PORT || '6379'),
+      retryStrategy: (times) => Math.min(times * 50, 2000)
+    });
   }
 
-  static async set(key: string, value: any, ttl = 3600) {
-    await redis.set(key, JSON.stringify(value), 'EX', ttl);
+  async get(key: string): Promise<Event[] | null> {
+    try {
+      const data = await this.redis.get(key);
+      return data ? JSON.parse(data) : null;
+    } catch (error) {
+      console.error('Cache get error:', error);
+      return null;
+    }
+  }
+
+  async set(key: string, events: Event[]): Promise<void> {
+    try {
+      await this.redis.setex(key, this.TTL, JSON.stringify(events));
+    } catch (error) {
+      console.error('Cache set error:', error);
+    }
+  }
+
+  async invalidate(): Promise<void> {
+    try {
+      await this.redis.flushdb();
+    } catch (error) {
+      console.error('Cache invalidate error:', error);
+    }
   }
 }

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -3,9 +3,10 @@ import { EventCache } from '../db/cache';
 import { validateEvent } from '../validators/event.validator';
 
 const router = Router();
+const cache = new EventCache();
 
 router.get('/', async (_req, res) => {
-  const events = await EventCache.get('events');
+  const events = await cache.get('events');
   res.json(events || []);
 });
 
@@ -14,9 +15,9 @@ router.post('/', async (req, res) => {
   if (!event) {
     return res.status(400).json({ error: 'Invalid event data' });
   }
-  const events = (await EventCache.get('events')) || [];
+  const events = (await cache.get('events')) || [];
   events.push(event);
-  await EventCache.set('events', events);
+  await cache.set('events', events);
   res.status(201).json(event);
 });
 

--- a/server/scrapers/base.scraper.ts
+++ b/server/scrapers/base.scraper.ts
@@ -1,0 +1,25 @@
+import { createHttpClient } from '../utils/http';
+import { checkRateLimit } from '../utils/queue';
+import { Event } from '../types/event';
+
+export abstract class BaseScraper {
+  protected httpClient = createHttpClient();
+
+  abstract scrape(url: string): Promise<Event[]>;
+
+  protected async fetchPage(url: string): Promise<string | null> {
+    try {
+      const domain = new URL(url).hostname;
+
+      if (!checkRateLimit(domain)) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+
+      const response = await this.httpClient.get(url);
+      return response.data;
+    } catch (error: any) {
+      console.error(`Failed to fetch ${url}:`, error.message);
+      return null;
+    }
+  }
+}

--- a/server/scrapers/event.scraper.ts
+++ b/server/scrapers/event.scraper.ts
@@ -1,12 +1,20 @@
-import axios from 'axios';
 import * as cheerio from 'cheerio';
 import { validateEvent } from '../validators/event.validator';
+import { Event } from '../types/event';
+import { BaseScraper } from './base.scraper';
 
-export class EventScraper {
-  async scrape(url: string) {
-    const { data } = await axios.get(url, { proxy: false });
-    const $ = cheerio.load(data);
-    const events: any[] = [];
+export class EventScraper extends BaseScraper {
+  async scrape(url: string): Promise<Event[]> {
+    const html = await this.fetchPage(url);
+    if (!html) return [];
+
+    return this.extractEvents(html, url);
+  }
+
+  private extractEvents(html: string, sourceUrl: string): Event[] {
+    const $ = cheerio.load(html);
+    const events: Event[] = [];
+
     $('.event').each((_, el) => {
       const title = $(el).find('h2').text().trim();
       const dateMatch = $(el).text().match(/\d{1,2}\/\d{1,2}\/\d{4}/);
@@ -15,7 +23,7 @@ export class EventScraper {
         title,
         description: $(el).text().trim(),
         date: dateMatch ? dateMatch[0] : undefined,
-        source: url,
+        source: sourceUrl,
         organizer: 'unknown',
         priority: 1,
         category: 'general',
@@ -24,6 +32,7 @@ export class EventScraper {
       });
       if (event) events.push(event);
     });
+
     return events;
   }
 }

--- a/server/types/event.ts
+++ b/server/types/event.ts
@@ -1,0 +1,25 @@
+export interface Event {
+  id: string;
+  title: string;
+  description?: string;
+  date?: string;
+  time?: string;
+  location?: string;
+  link?: string;
+  source: string;
+  organizer: string;
+  priority: number;
+  category: string;
+  deadline: boolean;
+  tags: string[];
+}
+
+export interface EventsResponse {
+  events: Event[];
+  metadata: {
+    totalEvents: number;
+    lastUpdated: string;
+    categories: string[];
+    sources: string[];
+  };
+}

--- a/server/utils/http.ts
+++ b/server/utils/http.ts
@@ -1,0 +1,25 @@
+import axios, { AxiosInstance } from 'axios';
+import axiosRetry from 'axios-retry';
+
+export const createHttpClient = (): AxiosInstance => {
+  const client = axios.create({
+    timeout: 10000,
+    proxy: false,
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (compatible; EventScraper/2.0)'
+    }
+  });
+
+  axiosRetry(client, {
+    retries: 3,
+    retryDelay: axiosRetry.exponentialDelay,
+    retryCondition: (error) => {
+      return (
+        axiosRetry.isNetworkOrIdempotentRequestError(error) ||
+        error.response?.status === 429
+      );
+    }
+  });
+
+  return client;
+};

--- a/server/utils/queue.ts
+++ b/server/utils/queue.ts
@@ -1,8 +1,23 @@
-import Bull from 'bull';
+import Queue from 'bull';
+import { Event } from '../types/event';
 
-export const scraperQueue = new Bull('scraper', {
+export const scraperQueue = new Queue('event-scraping', {
   redis: {
     host: process.env.REDIS_HOST || 'localhost',
-    port: Number(process.env.REDIS_PORT) || 6379
+    port: parseInt(process.env.REDIS_PORT || '6379')
   }
 });
+
+export const rateLimiter = new Map<string, number>();
+
+export function checkRateLimit(domain: string): boolean {
+  const now = Date.now();
+  const lastRequest = rateLimiter.get(domain) || 0;
+
+  if (now - lastRequest < 1000) {
+    return false;
+  }
+
+  rateLimiter.set(domain, now);
+  return true;
+}


### PR DESCRIPTION
## Summary
- define Event and EventsResponse types
- implement axios HTTP helper with retry logic
- add Redis-based EventCache class
- enhance scraper queue with rate limiting
- create BaseScraper and update EventScraper to use it
- update events route to use new cache API
- add axios-retry dependency

## Testing
- `npm run typecheck`
- `npm test`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68725fe7a6548323913ea273023e7fb0