### PR TITLE
Fix calendar API fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@types/node": "^20.11.0",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
+        "@types/supertest": "^6.0.3",
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.8",
         "@vitejs/plugin-react": "^4.3.1",
@@ -3552,6 +3553,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -3975,6 +3983,13 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -4065,6 +4080,30 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/swagger-jsdoc": {
       "version": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/node": "^20.11.0",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
+    "@types/supertest": "^6.0.3",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",
     "@vitejs/plugin-react": "^4.3.1",

--- a/server/__tests__/routes/events.test.ts
+++ b/server/__tests__/routes/events.test.ts
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import eventRoutes from '../../routes/events';
+
+jest.mock('../../db/cache', () => {
+  return {
+    EventCache: jest.fn().mockImplementation(() => ({
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined)
+    }))
+  };
+});
+
+jest.mock('../../scrapers/event.scraper', () => {
+  return {
+    EventScraper: jest.fn().mockImplementation(() => ({
+      scrape: jest.fn().mockResolvedValue([
+        {
+          id: '1',
+          title: 'Test Event',
+          source: 'https://example.org',
+          organizer: 'ExampleOrg',
+          priority: 1,
+          category: 'general',
+          deadline: false,
+          tags: []
+        }
+      ])
+    }))
+  };
+});
+
+const app = express();
+app.use('/api/events', eventRoutes);
+
+describe('GET /api/events', () => {
+  it('scrapes events when cache is empty', async () => {
+    const res = await request(app).get('/api/events');
+    expect(res.status).toBe(200);
+    expect(res.body.events).toHaveLength(1);
+    expect(res.body.metadata.totalEvents).toBe(1);
+  });
+});

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -1,13 +1,41 @@
 import { Router } from 'express';
 import { EventCache } from '../db/cache';
 import { validateEvent } from '../validators/event.validator';
+import { EventScraper } from '../scrapers/event.scraper';
 
 const router = Router();
 const cache = new EventCache();
 
 router.get('/', async (_req, res) => {
-  const events = await cache.get('events');
-  res.json(events || []);
+  let events = await cache.get('events');
+
+  if (!events || events.length === 0) {
+    try {
+      const scraper = new EventScraper();
+      const urls = (process.env.SCRAPER_URLS || 'https://example.org').split(',');
+      events = [];
+
+      for (const url of urls) {
+        const scraped = await scraper.scrape(url.trim());
+        events.push(...scraped);
+      }
+
+      await cache.set('events', events);
+    } catch (err) {
+      console.error('Failed to scrape events:', err);
+      events = [];
+    }
+  }
+
+  res.json({
+    events: events,
+    metadata: {
+      totalEvents: events.length,
+      lastUpdated: new Date().toISOString(),
+      categories: [...new Set(events.map((e) => e.category))],
+      sources: [...new Set(events.map((e) => e.organizer))]
+    }
+  });
 });
 
 router.post('/', async (req, res) => {


### PR DESCRIPTION
## Summary
- ensure `/api/events` scrapes sources when cache is empty
- test events route behaviour
- include supertest types for tests

## Testing
- `npm run test:server`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68727267a22883239c35c395e01cc007