### PR TITLE
Add zoom effect to loading counter

### DIFF
--- a/src/components/common/LoadingScreen.tsx
+++ b/src/components/common/LoadingScreen.tsx
@@ -22,9 +22,12 @@ const LoadingScreen: React.FC = () => {
 
   if (done) return null;
 
+  const scale = 1 + count / 50; // Zoom into the counter
+  const opacity = 1 - count / 100; // Fade out loader
+
   return (
-    <div className="rhizome-loader">
-      <div className="counter">{count}%</div>
+    <div className="rhizome-loader" style={{ opacity }}>
+      <div className="counter" style={{ transform: `scale(${scale})` }}>{count}%</div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add zoom animation and fade-out to loading counter

## Testing
- `npm test`
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6872d36e4834832393eb0db271b52800