### PR TITLE
Add zoom effect for loading screen counter

### DIFF
--- a/src/components/common/LoadingScreen.tsx
+++ b/src/components/common/LoadingScreen.tsx
@@ -34,7 +34,12 @@ const LoadingScreen: React.FC = () => {
 
   return (
     <div className="rhizome-loader">
-      <div className="counter" style={{ transform: `scale(${1 + count / 100})` }}>{count}%</div>
+      <div
+        className="counter"
+        style={{ transform: `scale(${1 + count / 10})` }}
+      >
+        {count}%
+      </div>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -523,7 +523,11 @@ html {
 
 .counter {
   font-size: 5rem;
-  color: #ffffff;
   font-weight: bold;
   transition: transform 0.2s ease-in-out;
+  color: transparent;
+  -webkit-text-stroke: 2px #ffffff;
+  background: url('/5-removebg-preview.png') center/cover no-repeat;
+  -webkit-background-clip: text;
+  background-clip: text;
 }


### PR DESCRIPTION
## Summary
- animate the loading screen counter so it zooms in dramatically
- display an image inside the counter text using background-clip

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872e56a5afc8323839653b36be75e19