### PR TITLE
Add zoom-in counter effect

### DIFF
--- a/src/components/common/LoadingScreen.tsx
+++ b/src/components/common/LoadingScreen.tsx
@@ -5,7 +5,7 @@ const LoadingScreen: React.FC = () => {
   const [done, setDone] = useState(false);
 
   useEffect(() => {
-    const scale = 1 + 0.2 * (count / 100);
+    const scale = 1 + 1.5 * (count / 100);
     document.body.style.transform = `scale(${scale})`;
 
     return () => {
@@ -34,7 +34,12 @@ const LoadingScreen: React.FC = () => {
 
   return (
     <div className="rhizome-loader">
-      <div className="counter" style={{ transform: `scale(${1 + count / 100})` }}>{count}%</div>
+      <div
+        className="counter"
+        style={{ transform: `scale(${1 + 9 * (count / 100)})` }}
+      >
+        {count}%
+      </div>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -529,4 +529,5 @@ html {
   -webkit-text-stroke: 2px #ffffff;
   mix-blend-mode: screen;
   transition: transform 0.2s ease-in-out;
+  transform-origin: center;
 }


### PR DESCRIPTION
## Summary
- zoom in on load by increasing body scale in `LoadingScreen`
- cut loader background with counter text so the page shows through

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872e56a5afc8323839653b36be75e19