### PR TITLE
Update logo references

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,7 +10,7 @@ const Header: React.FC = () => {
       <div className="container flex flex-col items-center">
         {/* Logo at the top */}
         <img
-          src="public/20250710_0555_Rhizome Logo Design_remix_01jzt2tem6e8zse9br715pa28n (2).png" // Place rhizome-logo.png in your public directory
+          src="/public/20250710_0555_Rhizome Logo Design_remix_01jzt2tem6e8zse9br715pa28n (2).png" // Place rhizome-logo.png in your public directory
           alt="Rhizome Logo"
           style={{ height: '96px', marginBottom: '1rem' }}
         />

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -5,7 +5,7 @@ import { Menu, X, Globe, ChevronDown } from 'lucide-react';
 
 // Logo image sourced from the public folder. This image was provided in the
 // repository and represents the Rhizome branding colors.
-import LogoImage from '/5-removebg-preview.png';
+import LogoImage from '/20250710_0555_Rhizome Logo Design_remix_01jzt2tem6e8zse9br715pa28n (2).png';
 import { useLanguage, languages } from '../../contexts/LanguageContext';
 
 const Navigation: React.FC = () => {

--- a/src/pages/RhizomeCanadaSubpage.tsx
+++ b/src/pages/RhizomeCanadaSubpage.tsx
@@ -91,9 +91,9 @@ const RhizomeCanadaSubpage: React.FC = () => {
           >
             {/* Logo Integration */}
             <div className="rc-logo-container justify-center mb-8">
-              <img 
-                src="/public/20250626_0153_Upscaled Vector Design_remix_01jynkghz8fg4v5w094qqj0epj.png" 
-                alt="Rhizome Canada Logo" 
+              <img
+                src="/public/20250710_0555_Rhizome Logo Design_remix_01jzt2tem6e8zse9br715pa28n (2).png"
+                alt="Rhizome Canada Logo"
                 className="h-20 w-auto rc-float"
               />
             </div>


### PR DESCRIPTION
## Summary
- update Navigation logo to new asset
- use new logo asset in Header
- use new logo for Rhizome Canada page

## Testing
- `npm test`
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6873254e9d248323b0352f779354df19