### PR TITLE
Add modern visual identity theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,10 @@ Copy `.env.example` to `.env` and adjust the values as needed. Currently only `P
 - To deploy on Netlify, create a new site pointing to this repository and enable SSL in the Netlify dashboard. If Netlify refuses to provision SSL, verify that your domain DNS records point to Netlify and that no conflicting certificates exist.
 - The codebase does not currently integrate with Supabase or Neon. Any references to those services are likely from previous experiments or external configurations not present in this repository.
 
-\n## License\n\nThis project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+## Visual Identity Proposal
+
+An experimental theme is available under `src/styles/modern-identity.css`. Import this stylesheet and add the `modern-theme` class to the `<body>` element to try a new purple-based color palette and updated typography.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@
     <meta name="description" content="Building collaborative networks to strengthen civil society through community-led initiatives." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Noto+Sans+Arabic:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@300;400;500;600;700&family=Noto+Sans+Arabic:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Optional experimental theme -->
+    <link rel="stylesheet" href="/src/styles/modern-identity.css">
     
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&family=Poppins:wght@300;400;500;600;700&family=Noto+Sans+Arabic:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;500;600;700&family=Poppins:wght@300;400;500;600;700&family=Noto+Sans+Arabic:wght@300;400;500;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/src/styles/modern-identity.css
+++ b/src/styles/modern-identity.css
@@ -1,0 +1,20 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* Modern Visual Identity */
+:root {
+  --primary-color: #4c1d95;
+  --secondary-color: #7e22ce;
+  --accent-color: #a21caf;
+  --text-color: #1e293b;
+  --bg-color: #f5f3ff;
+  --card-bg: #ffffff;
+  --border-radius: 10px;
+  --shadow: 0 4px 18px rgba(0,0,0,0.08);
+  --shadow-lg: 0 12px 48px rgba(0,0,0,0.12);
+}
+
+body.modern-theme {
+  font-family: 'Inter', 'Poppins', sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,6 +40,18 @@ export default {
           800: '#9d174d',
           900: '#831843',
         },
+        modern: {
+          50: '#f5f3ff',
+          100: '#ede9fe',
+          200: '#ddd6fe',
+          300: '#c4b5fd',
+          400: '#a78bfa',
+          500: '#8b5cf6',
+          600: '#7e22ce',
+          700: '#6b21a8',
+          800: '#581c87',
+          900: '#4c1d95',
+        },
         rhizome: {
           green: '#065f46',
           blue: '#3b82f6',
@@ -77,6 +89,7 @@ export default {
       fontFamily: {
         'arabic': ['Noto Sans Arabic', 'Arial', 'sans-serif'],
         'sans': ['Poppins', 'Noto Sans Arabic', 'Arial', 'sans-serif'],
+        'inter': ['Inter', 'Poppins', 'Noto Sans Arabic', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- introduce `modern-identity.css` with purple color palette
- import Inter font in `index.html` and `index.css`
- hook up optional modern theme CSS
- extend Tailwind config with `modern` colors and Inter font
- document the new theme in README

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687345bccca0832392e91e35d5a38c10