### PR TITLE
Update fonts and colors for new identity

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Building collaborative networks to strengthen civil society through community-led initiatives." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Noto+Sans+Arabic:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Lato:wght@300;400;700&family=Noto+Sans+Arabic:wght@300;400;500;700&display=swap" rel="stylesheet">
     
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>

--- a/src/components/home/AboutPreview.tsx
+++ b/src/components/home/AboutPreview.tsx
@@ -38,7 +38,7 @@ const AboutPreview: React.FC = () => {
             transition={{ duration: 0.8 }}
             className={currentLanguage.code === 'ar' ? 'font-arabic' : ''}
           >
-            <h2 className="text-4xl font-bold text-stone-900 mb-6" style={{ fontFamily: '"Playfair Display", "Noto Sans Arabic", serif' }}>
+            <h2 className="text-4xl font-bold text-stone-900 mb-6" style={{ fontFamily: '"Montserrat", "Noto Sans Arabic", sans-serif' }}>
               {t('about-title', 'Our Purpose', 'رسالتنا')}
             </h2>
             

--- a/src/components/home/CommunityPreview.tsx
+++ b/src/components/home/CommunityPreview.tsx
@@ -38,7 +38,7 @@ const CommunityPreview: React.FC = () => {
           transition={{ duration: 0.8 }}
           className={`text-center mb-16 ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}
         >
-          <h2 className="text-4xl font-bold text-stone-900 mb-6" style={{ fontFamily: '"Playfair Display", "Noto Sans Arabic", serif' }}>
+          <h2 className="text-4xl font-bold text-stone-900 mb-6" style={{ fontFamily: '"Montserrat", "Noto Sans Arabic", sans-serif' }}>
             {t('community-wall-title', 'Community Canvas', 'لوحة المجتمع')}
           </h2>
           <p className="text-xl text-stone-600 max-w-3xl mx-auto mb-8">

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -182,7 +182,7 @@ const HeroSection: React.FC = () => {
             initial={{ opacity: 0, scale: 0.8 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 1.2, delay: 0.3 }}
-            style={{ fontFamily: '"Playfair Display", "Noto Sans Arabic", serif' }}
+            style={{ fontFamily: '"Montserrat", "Noto Sans Arabic", sans-serif' }}
           >
             {t('hero-title', 'Rhizome Community Foundation', 'مؤسسة ريزوم المجتمعية')}
           </motion.h1>

--- a/src/components/home/InteractiveMap.tsx
+++ b/src/components/home/InteractiveMap.tsx
@@ -249,7 +249,7 @@ const InteractiveMap: React.FC = () => {
           viewport={{ once: true }}
           transition={{ duration: 0.8 }}
         >
-          <h2 className={`text-3xl font-bold text-center mb-8 text-emerald-800 ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`} style={{ fontFamily: '"Playfair Display", "Noto Sans Arabic", serif' }}>
+          <h2 className={`text-3xl font-bold text-center mb-8 text-emerald-800 ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`} style={{ fontFamily: '"Montserrat", "Noto Sans Arabic", sans-serif' }}>
             {t('map-title', 'Interactive Activities Map', 'خريطة الأنشطة التفاعلية')}
           </h2>
           <p className={`text-center text-gray-600 mb-10 max-w-3xl mx-auto ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&family=Poppins:wght@300;400;500;600;700&family=Noto+Sans+Arabic:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Lato:wght@300;400;700&family=Noto+Sans+Arabic:wght@300;400;500;700&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -18,11 +18,11 @@
 
 /* Design System Variables */
 :root {
-  --primary-color: #064e3b;
-  --secondary-color: #047857;
-  --accent-color: #b91c1c;
-  --text-color: #1f2937;
-  --bg-color: #fafaf9;
+  --primary-color: #0f172a;
+  --secondary-color: #334155;
+  --accent-color: #f59e0b;
+  --text-color: #111827;
+  --bg-color: #f9fafb;
   --card-bg: #ffffff;
   --border-radius: 12px;
   --shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
@@ -74,7 +74,7 @@
 
 /* Base Styles */
 body {
-  font-family: 'Poppins', 'Noto Sans Arabic', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: 'Lato', 'Noto Sans Arabic', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   margin: 0;
   padding: 0;
   background-color: var(--bg-color);
@@ -113,7 +113,7 @@ body {
   margin-bottom: 1.5rem;
   text-align: center;
   line-height: 1.2;
-  font-family: 'Playfair Display', 'Noto Sans Arabic', serif;
+  font-family: 'Montserrat', 'Noto Sans Arabic', sans-serif;
 }
 
 .section-description {

--- a/src/pages/RhizomeSyriaPage.tsx
+++ b/src/pages/RhizomeSyriaPage.tsx
@@ -168,7 +168,7 @@ const RhizomeSyriaPage: React.FC = () => {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.5 }}
               className="text-6xl md:text-7xl font-bold mb-6 bg-gradient-to-r from-purple-600 via-blue-600 via-orange-500 to-red-500 bg-clip-text text-transparent"
-              style={{ fontFamily: '"Playfair Display", "Noto Sans Arabic", serif' }}
+              style={{ fontFamily: '"Montserrat", "Noto Sans Arabic", sans-serif' }}
             >
               {t('rhizome-syria-title', 'Rhizome Syria', 'ريزوم سوريا')}
             </motion.h1>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -75,8 +75,9 @@ export default {
         }
       },
       fontFamily: {
-        'arabic': ['Noto Sans Arabic', 'Arial', 'sans-serif'],
-        'sans': ['Poppins', 'Noto Sans Arabic', 'Arial', 'sans-serif'],
+        arabic: ['Noto Sans Arabic', 'Arial', 'sans-serif'],
+        sans: ['Lato', 'Noto Sans Arabic', 'Arial', 'sans-serif'],
+        heading: ['Montserrat', 'Noto Sans Arabic', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- refresh color palette and fonts for new Montserrat/Lato identity
- update Tailwind config font families
- swap font in hero, about preview, community preview, map, and Syria page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687345bccca0832392e91e35d5a38c10