### PR TITLE
Disable text selection and right click

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,9 @@ body {
   color: var(--text-color);
   line-height: 1.6;
   overflow-x: hidden;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   transition: background-color 0.3s ease;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,10 @@ import * as Sentry from '@sentry/react';
 import App from './App.tsx';
 import './index.css';
 
+// Disable right click and text selection globally
+document.addEventListener('contextmenu', (e) => e.preventDefault());
+document.addEventListener('selectstart', (e) => e.preventDefault());
+
 Sentry.init({
   dsn: 'https://81ccc90ca72193f24ec2ea5ef405d121@o4509617082269696.ingest.us.sentry.io/4509622411853824',
   sendDefaultPii: true,


### PR DESCRIPTION
## Summary
- disable context menu and text selection globally
- prevent selecting text via CSS

## Testing
- `npm test`
- `npx eslint .` *(fails: 74 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6873aad1088083238d3205a5455e4210