### PR TITLE
Disable text selection and right click

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { LanguageProvider } from './contexts/LanguageContext';
 import { PhotoProvider } from './contexts/PhotoContext';
@@ -21,6 +21,13 @@ import CustomCursor from './components/common/CustomCursor';
 import LoadingScreen from './components/common/LoadingScreen';
 
 function App() {
+  useEffect(() => {
+    const preventContextMenu = (e: MouseEvent) => e.preventDefault();
+    document.addEventListener('contextmenu', preventContextMenu);
+    return () => {
+      document.removeEventListener('contextmenu', preventContextMenu);
+    };
+  }, []);
   return (
     <LanguageProvider>
       <UserProvider>

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,10 @@
 /* Custom Cursor */
 * {
   cursor: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 /* Custom styles for Arabic text */


### PR DESCRIPTION
## Summary
- disable text selection via `user-select: none`
- block the browser context menu globally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873aad1088083238d3205a5455e4210