### PR TITLE
Implement startup scraping and caching

### DIFF
--- a/server/__tests__/events.api.test.ts
+++ b/server/__tests__/events.api.test.ts
@@ -1,0 +1,37 @@
+import request from 'supertest';
+import express from 'express';
+import eventRoutes from '../routes/events';
+
+jest.mock('../utils/scrape', () => {
+  const events = [
+    {
+      id: '1',
+      title: 'Mock Event',
+      source: 'https://example.org',
+      organizer: 'test',
+      priority: 1,
+      category: 'general',
+      deadline: false,
+      tags: [],
+    },
+  ];
+  return {
+    cache: {
+      get: jest.fn(async () => null),
+      set: jest.fn(),
+      ttl: jest.fn(async () => -2),
+    },
+    scrapeAndCache: jest.fn(async () => events),
+  };
+});
+
+const app = express();
+app.use('/api/events', eventRoutes);
+
+describe('GET /api/events', () => {
+  it('returns events from scraper when cache empty', async () => {
+    const res = await request(app).get('/api/events');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+});

--- a/server/__tests__/globals.d.ts
+++ b/server/__tests__/globals.d.ts
@@ -1,0 +1,1 @@
+declare module 'supertest';

--- a/server/db/cache.ts
+++ b/server/db/cache.ts
@@ -23,6 +23,15 @@ export class EventCache {
     }
   }
 
+  async ttl(key: string): Promise<number> {
+    try {
+      return await this.redis.ttl(key);
+    } catch (error) {
+      console.error('Cache ttl error:', error);
+      return -2;
+    }
+  }
+
   async set(key: string, events: Event[]): Promise<void> {
     try {
       await this.redis.setex(key, this.TTL, JSON.stringify(events));

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,8 @@ import { swaggerSpec } from './swagger';
 import swaggerUi from 'swagger-ui-express';
 import eventRoutes from './routes/events';
 import healthRoutes from './routes/health';
+import './jobs/scraper.job';
+import { scrapeAndCache } from './utils/scrape';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -56,6 +58,9 @@ process.on('SIGTERM', () => {
 const server = app.listen(PORT, () => {
   logger.info(`Enhanced Calendar API server listening on port ${PORT}`);
   logger.info(`API Documentation available at http://localhost:${PORT}/api-docs`);
+  scrapeAndCache().catch((err) =>
+    logger.error('Initial scrape failed:', err)
+  );
 });
 
 export default app;

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -1,12 +1,15 @@
 import { Router } from 'express';
-import { EventCache } from '../db/cache';
 import { validateEvent } from '../validators/event.validator';
+import { scrapeAndCache, cache } from '../utils/scrape';
 
 const router = Router();
-const cache = new EventCache();
 
 router.get('/', async (_req, res) => {
-  const events = await cache.get('events');
+  let events = await cache.get('events');
+  const ttl = await cache.ttl('events');
+  if (!events || ttl <= 0) {
+    events = await scrapeAndCache();
+  }
   res.json(events || []);
 });
 

--- a/server/utils/scrape.ts
+++ b/server/utils/scrape.ts
@@ -1,0 +1,24 @@
+import { EventScraper } from '../scrapers/event.scraper';
+import { EventCache } from '../db/cache';
+import { Event } from '../types/event';
+
+const SCRAPE_URLS = process.env.SCRAPE_URLS?.split(',') || ['https://example.org'];
+const cache = new EventCache();
+
+export async function scrapeAndCache(): Promise<Event[]> {
+  const scraper = new EventScraper();
+  let events: Event[] = [];
+
+  for (const url of SCRAPE_URLS) {
+    const scraped = await scraper.scrape(url);
+    events = events.concat(scraped);
+  }
+
+  if (events.length > 0) {
+    await cache.set('events', events);
+  }
+
+  return events;
+}
+
+export { cache };


### PR DESCRIPTION
## Summary
- add a TTL helper for Redis cache
- create scraper utility to scrape pages and populate Redis
- trigger scraping job and cache on server startup
- refresh cache on `/api/events` when empty or expired
- test `/api/events` with mocked scrape

## Testing
- `npm run lint:server`
- `npm run test:server`

------
https://chatgpt.com/codex/tasks/task_e_6873b25abd488323a10227d79554e74b