### PR TITLE
Map category colors to hex codes and add snapshot test

### DIFF
--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -31,14 +31,14 @@ const CalendarPage: React.FC = () => {
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
 
   const categories = [
-    { key: 'all', en: 'All Events', ar: 'جميع الفعاليات', color: 'bg-gray-500' },
-    { key: 'funding', en: 'Funding', ar: 'التمويل', color: 'bg-green-500' },
-    { key: 'workshop', en: 'Workshops', ar: 'ورش العمل', color: 'bg-blue-500' },
-    { key: 'conference', en: 'Conferences', ar: 'المؤتمرات', color: 'bg-purple-500' },
-    { key: 'cultural', en: 'Cultural', ar: 'ثقافية', color: 'bg-pink-500' },
-    { key: 'educational', en: 'Educational', ar: 'تعليمية', color: 'bg-orange-500' },
-    { key: 'networking', en: 'Networking', ar: 'تواصل', color: 'bg-indigo-500' },
-    { key: 'general', en: 'General', ar: 'عام', color: 'bg-gray-500' }
+    { key: 'all', en: 'All Events', ar: 'جميع الفعاليات', color: '#6b7280' },
+    { key: 'funding', en: 'Funding', ar: 'التمويل', color: '#22c55e' },
+    { key: 'workshop', en: 'Workshops', ar: 'ورش العمل', color: '#3b82f6' },
+    { key: 'conference', en: 'Conferences', ar: 'المؤتمرات', color: '#a855f7' },
+    { key: 'cultural', en: 'Cultural', ar: 'ثقافية', color: '#ec4899' },
+    { key: 'educational', en: 'Educational', ar: 'تعليمية', color: '#f97316' },
+    { key: 'networking', en: 'Networking', ar: 'تواصل', color: '#6366f1' },
+    { key: 'general', en: 'General', ar: 'عام', color: '#6b7280' }
   ];
 
   const initialEvents: CalendarEvent[] = [];
@@ -130,12 +130,15 @@ const CalendarPage: React.FC = () => {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: index * 0.05 }}
               className="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-shadow border-l-4"
-              style={{ borderLeftColor: category?.color?.replace('bg-', '#') || '#6b7280' }}
+              style={{ borderLeftColor: category?.color || '#6b7280' }}
             >
               <div className="flex items-start justify-between mb-4">
                 <div className="flex-1">
                   <div className="flex items-center mb-2">
-                    <div className={`w-3 h-3 rounded-full mr-3 ${category?.color || 'bg-gray-500'}`} />
+                    <div
+                      className="w-3 h-3 rounded-full mr-3"
+                      style={{ backgroundColor: category?.color || '#6b7280' }}
+                    />
                     <span className={`text-xs font-medium text-stone-500 uppercase tracking-wide ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}>
                       {t(`category-${event.category}`, event.category, event.category)}
                     </span>

--- a/tests/__snapshots__/calendarPageColor.test.tsx.snap
+++ b/tests/__snapshots__/calendarPageColor.test.tsx.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CalendarPage color styles > renders event with hex border color 1`] = `
+<div
+  animate="[object Object]"
+  class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-shadow border-l-4"
+  initial="[object Object]"
+  style="border-left-color: rgb(34, 197, 94);"
+  transition="[object Object]"
+>
+  <div
+    class="flex items-start justify-between mb-4"
+  >
+    <div
+      class="flex-1"
+    >
+      <div
+        class="flex items-center mb-2"
+      >
+        <div
+          class="w-3 h-3 rounded-full mr-3"
+          style="background-color: rgb(34, 197, 94);"
+        />
+        <span
+          class="text-xs font-medium text-stone-500 uppercase tracking-wide "
+        >
+          funding
+        </span>
+      </div>
+      <h3
+        class="text-xl font-bold text-stone-900 mb-2 "
+      >
+        Test Event
+      </h3>
+    </div>
+  </div>
+  <div
+    class="grid md:grid-cols-2 lg:grid-cols-4 gap-4 text-sm text-stone-600 mb-4"
+  />
+  <div
+    class="flex items-center justify-between pt-4 border-t border-stone-200"
+  >
+    <div
+      class="flex items-center space-x-4"
+    >
+      <span
+        class="text-sm text-stone-500 "
+      >
+        Organized by
+         
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/tests/calendarPageColor.test.tsx
+++ b/tests/calendarPageColor.test.tsx
@@ -1,0 +1,49 @@
+import { render, waitFor, screen } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+import CalendarPage from '../src/pages/CalendarPage';
+import { LanguageProvider } from '../src/contexts/LanguageContext';
+
+const mockEvents = [
+  { id: '1', title: 'Test Event', titleAr: 'اختبار', category: 'funding' }
+];
+
+vi.stubGlobal(
+  'fetch',
+  vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({ events: mockEvents, metadata: { lastUpdated: '2025-01-01T00:00:00.000Z' } }),
+    })
+  ) as any
+);
+
+vi.useFakeTimers();
+
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual<any>('framer-motion');
+  return {
+    ...actual,
+    motion: {
+      div: (props: any) => <div {...props} />,
+    },
+  };
+});
+
+vi.useRealTimers();
+
+describe('CalendarPage color styles', () => {
+  it('renders event with hex border color', async () => {
+    const { container } = render(
+      <LanguageProvider>
+        <CalendarPage />
+      </LanguageProvider>
+    );
+    await waitFor(() => expect(screen.getByText('Test Event')).toBeInTheDocument());
+
+    const eventDiv = container.querySelector('.border-l-4');
+    expect(eventDiv).toHaveStyle({ borderLeftColor: '#22c55e' });
+    expect(eventDiv).toMatchSnapshot();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
     setupFiles: './src/test/setup.ts',
     css: true,
     exclude: ['server/**', 'node_modules/**'],
-    include: ['tests/**/*.ts']
+    include: ['tests/**/*.{ts,tsx}']
   },
 });


### PR DESCRIPTION
## Summary
- map calendar categories to hex codes
- inline background color styling for calendar list view
- allow vitest to include tsx tests
- snapshot test for calendar page color styling

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6873b261ba9c8323860b54d6d946b0c9