### PR TITLE
Add donation section with API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ SENTRY_DSN=your-sentry-dsn
 LOG_LEVEL=info
 API_URL=https://api.yourdomain.com
 ALLOWED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
+
+DONATION_ETRANSFER=email@example.com
+DONATION_CRYPTO_WALLET=0x123...
+DONATION_PAYPAL_LINK=https://paypal.me/example

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "joi": "^17.13.3",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.453.0",
+        "qrcode.react": "^3.2.0",
         "react": "^18.3.1",
         "react-big-calendar": "^1.19.4",
         "react-dom": "^18.3.1",
@@ -11657,6 +11658,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qrcode.react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
+      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "joi": "^17.13.3",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.453.0",
+    "qrcode.react": "^3.2.0",
     "react": "^18.3.1",
     "react-big-calendar": "^1.19.4",
     "react-dom": "^18.3.1",

--- a/server/__tests__/donations.routes.test.ts
+++ b/server/__tests__/donations.routes.test.ts
@@ -1,0 +1,22 @@
+import request from 'supertest';
+import express from 'express';
+import donationRoutes from '../routes/donations';
+
+describe('GET /api/donations', () => {
+  it('returns donation info from env', async () => {
+    process.env.DONATION_ETRANSFER = 'test@example.com';
+    process.env.DONATION_CRYPTO_WALLET = '0xtest';
+    process.env.DONATION_PAYPAL_LINK = 'https://paypal.me/test';
+
+    const app = express();
+    app.use('/api/donations', donationRoutes);
+
+    const res = await request(app).get('/api/donations');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      etransfer: 'test@example.com',
+      cryptoWallet: '0xtest',
+      paypal: 'https://paypal.me/test'
+    });
+  });
+});

--- a/server/__tests__/events.routes.test.ts
+++ b/server/__tests__/events.routes.test.ts
@@ -6,7 +6,10 @@ import eventRoutes from '../routes/events';
 import { EventCache } from '../db/cache';
 import Redis from 'ioredis';
 
-jest.mock('ioredis', () => import('ioredis-mock'));
+jest.mock('ioredis', () => {
+  const RedisMock = require('ioredis-mock');
+  return { __esModule: true, default: RedisMock };
+});
 
 describe('Events API integration', () => {
   let app: express.Express;

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import { swaggerSpec } from './swagger';
 import swaggerUi from 'swagger-ui-express';
 import eventRoutes from './routes/events';
 import healthRoutes from './routes/health';
+import donationRoutes from './routes/donations';
 import './jobs/scraper.job';
 import { scrapeAndCache } from './utils/scrape';
 
@@ -37,6 +38,7 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 app.use('/api/events', eventRoutes);
 app.use('/api/health', healthRoutes);
+app.use('/api/donations', donationRoutes);
 
 app.use(
   (err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/server/routes/donations.ts
+++ b/server/routes/donations.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({
+    etransfer: process.env.DONATION_ETRANSFER || '',
+    cryptoWallet: process.env.DONATION_CRYPTO_WALLET || '',
+    paypal: process.env.DONATION_PAYPAL_LINK || ''
+  });
+});
+
+export default router;

--- a/server/utils/queue.ts
+++ b/server/utils/queue.ts
@@ -1,11 +1,14 @@
 import Queue from 'bull';
 
-export const scraperQueue = new Queue('event-scraping', {
-  redis: {
-    host: process.env.REDIS_HOST || 'localhost',
-    port: parseInt(process.env.REDIS_PORT || '6379')
-  }
-});
+export const scraperQueue =
+  process.env.NODE_ENV === 'test'
+    ? ({} as any)
+    : new Queue('event-scraping', {
+        redis: {
+          host: process.env.REDIS_HOST || 'localhost',
+          port: parseInt(process.env.REDIS_PORT || '6379')
+        }
+      });
 
 export const rateLimiter = new Map<string, number>();
 

--- a/src/components/home/DonationSection.tsx
+++ b/src/components/home/DonationSection.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { useLanguage } from '../../contexts/LanguageContext';
+import QRCode from 'qrcode.react';
+
+interface DonationInfo {
+  etransfer: string;
+  cryptoWallet: string;
+  paypal: string;
+}
+
+const DonationSection: React.FC = () => {
+  const { t, currentLanguage } = useLanguage();
+  const [info, setInfo] = useState<DonationInfo | null>(null);
+
+  useEffect(() => {
+    fetch('/api/donations')
+      .then((res) => res.json())
+      .then((data) => setInfo(data))
+      .catch(() => setInfo(null));
+  }, []);
+
+  if (!info) return null;
+
+  return (
+    <section id="donate" className="py-20 bg-white">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 space-y-8 text-center">
+        <h2
+          className="text-4xl font-bold text-stone-900"
+          style={{ fontFamily: '"Playfair Display", "Noto Sans Arabic", serif' }}
+        >
+          {t('donate-title', 'Support Our Work', 'ادعم عملنا')}
+        </h2>
+        <p
+          className={`text-lg text-stone-600 ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}
+        >
+          {t(
+            'donate-description',
+            'Your contributions help us continue community initiatives.',
+            'مساهماتكم تساعدنا في مواصلة مبادرات المجتمع.'
+          )}
+        </p>
+        <div className="grid md:grid-cols-3 gap-8">
+          <div className="space-y-4">
+            <h3 className="font-semibold">E-Transfer</h3>
+            <p className="break-all text-sm">{info.etransfer}</p>
+          </div>
+          <div className="space-y-4">
+            <h3 className="font-semibold">Crypto Wallet</h3>
+            <p className="break-all text-sm">{info.cryptoWallet}</p>
+            {info.cryptoWallet && <QRCode value={info.cryptoWallet} size={120} />}
+          </div>
+          <div className="space-y-4">
+            <h3 className="font-semibold">PayPal</h3>
+            {info.paypal && (
+              <a
+                href={info.paypal}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+              >
+                Donate with PayPal
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default DonationSection;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -89,6 +89,11 @@ const Footer: React.FC = () => {
         </div>
 
         <div className="border-t border-gray-800 mt-8 pt-8 text-center space-y-2">
+          <p className="text-gray-300">
+            <Link to="/#donate" className="underline hover:text-white">
+              {t('donate-short', 'Support our work', 'ادعم عملنا')}
+            </Link>
+          </p>
           <p className={`text-yellow-400 ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}>
             {t(
               'experimental-release',

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import HeroSection from '../components/home/HeroSection';
 import AboutPreview from '../components/home/AboutPreview';
 import ProgramsPreview from '../components/home/ProgramsPreview';
 import CommunityPreview from '../components/home/CommunityPreview';
+import DonationSection from '../components/home/DonationSection';
 import InteractiveMap from '../components/home/InteractiveMap';
 import SentryTestButton from '../components/common/SentryTestButton';
 
@@ -14,6 +15,7 @@ const HomePage: React.FC = () => {
       <ProgramsPreview />
       <InteractiveMap />
       <CommunityPreview />
+      <DonationSection />
       <SentryTestButton />
     </div>
   );


### PR DESCRIPTION
## Summary
- expose `/api/donations` endpoint
- include donation config in `.env.example`
- add DonationSection to home page and link from footer
- support PayPal, e‑transfer and crypto wallet
- install `qrcode.react` for QR codes
- update tests and queue util to avoid Redis in test env

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875e291e97c83238ba5469ffed8cb31