### PR TITLE
Implement countdown zoom intro

### DIFF
--- a/src/components/common/LoadingScreen.tsx
+++ b/src/components/common/LoadingScreen.tsx
@@ -1,30 +1,40 @@
 import React, { useEffect, useState } from 'react';
 
 const LoadingScreen: React.FC = () => {
-  const [count, setCount] = useState(0);
+  const [count, setCount] = useState(3);
+  const [scale, setScale] = useState(1);
   const [done, setDone] = useState(false);
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    const countdown = setInterval(() => {
       setCount(c => {
-        if (c >= 100) {
-          clearInterval(interval);
+        if (c <= 1) {
+          clearInterval(countdown);
           document.body.classList.add('loaded');
           setDone(true);
-          return 100;
+          return 0;
         }
-        return c + 1;
+        return c - 1;
       });
-    }, 20);
+    }, 1000);
 
-    return () => clearInterval(interval);
+    const zoom = setInterval(() => {
+      setScale(s => s + 0.05);
+    }, 50);
+
+    return () => {
+      clearInterval(countdown);
+      clearInterval(zoom);
+    };
   }, []);
 
   if (done) return null;
 
   return (
     <div className="rhizome-loader">
-      <div className="counter">{count}%</div>
+      <div className="count-number" style={{ transform: `scale(${scale})` }}>
+        {count}
+      </div>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -521,10 +521,15 @@ html {
   justify-content: center;
   align-items: center;
   z-index: 9999;
+  isolation: isolate;
+  overflow: hidden;
 }
 
-.counter {
-  font-size: 5rem;
-  color: #ffffff;
-  font-weight: bold;
+.count-number {
+  font-size: 20vw;
+  font-weight: 700;
+  color: #000;
+  mix-blend-mode: destination-out;
+  transition: transform 0.3s ease-out;
+  line-height: 1;
 }


### PR DESCRIPTION
## Summary
- animate the loading screen with a 3-2-1 countdown
- display the website through the numbers using a blend mask
- zoom in towards the numbers during the countdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68770b66e3588323aea94132d4bb3c32