### PR TITLE
Add zoom intro for landing page

### DIFF
--- a/src/components/home/NumberZoomIntro.tsx
+++ b/src/components/home/NumberZoomIntro.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { motion, useAnimation } from 'framer-motion';
+
+const NumberZoomIntro: React.FC = () => {
+  const controls = useAnimation();
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const run = async () => {
+      await controls.start({
+        scale: [1, 2, 15],
+        filter: ['blur(0px)', 'blur(3px)', 'blur(8px)'],
+        transition: { duration: 4, ease: 'easeInOut', times: [0, 0.7, 1] },
+      });
+      await controls.start({
+        opacity: 0,
+        transition: { duration: 0.8, ease: 'easeInOut' },
+      });
+      setVisible(false);
+    };
+    run();
+  }, [controls]);
+
+  if (!visible) return null;
+
+  return (
+    <motion.div
+      className="absolute inset-0 flex items-center justify-center bg-black z-50 overflow-hidden pointer-events-none"
+      animate={controls}
+    >
+      <motion.h1
+        className="font-bold leading-none"
+        style={{
+          fontSize: '35vw',
+          color: 'transparent',
+          WebkitTextStroke: '2px white',
+          mixBlendMode: 'screen',
+        }}
+      >
+        2025
+      </motion.h1>
+    </motion.div>
+  );
+};
+
+export default NumberZoomIntro;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import HeroSection from '../components/home/HeroSection';
+import NumberZoomIntro from '../components/home/NumberZoomIntro';
 import AboutPreview from '../components/home/AboutPreview';
 import ProgramsPreview from '../components/home/ProgramsPreview';
 import CommunityPreview from '../components/home/CommunityPreview';
@@ -8,7 +9,8 @@ import SentryTestButton from '../components/common/SentryTestButton';
 
 const HomePage: React.FC = () => {
   return (
-    <div>
+    <div className="relative">
+      <NumberZoomIntro />
       <HeroSection />
       <AboutPreview />
       <ProgramsPreview />


### PR DESCRIPTION
## Summary
- animate macro zoom through numbers before hero section

## Testing
- `npm test`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_6877381f7a2c8323bfd0fa762688f22c