### PR TITLE
Add numeric zoom intro overlay

### DIFF
--- a/server/__tests__/events.routes.test.ts
+++ b/server/__tests__/events.routes.test.ts
@@ -6,6 +6,7 @@ import eventRoutes from '../routes/events';
 import { EventCache } from '../db/cache';
 import Redis from 'ioredis';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('ioredis', () => require('ioredis-mock'));
 
 describe('Events API integration', () => {

--- a/server/db/cache.ts
+++ b/server/db/cache.ts
@@ -1,7 +1,8 @@
 import Redis from 'ioredis';
 
 // Use in-memory Redis mock when running tests to avoid external dependency
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+ 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const MockRedis = process.env.NODE_ENV === 'test' ? require('ioredis-mock') : null;
 import { Event } from '../types/event';
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import KnowledgeHubPage from './pages/KnowledgeHubPage';
 import ParticleSystem from './components/common/ParticleSystem';
 import CustomCursor from './components/common/CustomCursor';
 import LoadingScreen from './components/common/LoadingScreen';
+import NumericZoomIntro from './components/common/NumericZoomIntro';
 
 function App() {
   return (
@@ -28,6 +29,7 @@ function App() {
           <Router>
           <div className="min-h-screen bg-gradient-to-br from-stone-50 to-emerald-50">
             <LoadingScreen />
+            <NumericZoomIntro />
             <CustomCursor />
             <Navigation />
             <main>

--- a/src/components/common/NumericZoomIntro.tsx
+++ b/src/components/common/NumericZoomIntro.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { motion, useAnimation } from 'framer-motion';
+
+const NumericZoomIntro: React.FC = () => {
+  const controls = useAnimation();
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    const sequence = async () => {
+      await controls.start({
+        scale: [1, 3, 10],
+        filter: ["blur(0px)", "blur(2px)", "blur(0px)"],
+        transition: { duration: 4, ease: "easeInOut" },
+      });
+      await controls.start({ opacity: 0, transition: { duration: 0.8 } });
+      setHidden(true);
+    };
+    sequence();
+  }, [controls]);
+
+  if (hidden) return null;
+  return (
+    <motion.div className="numeric-zoom-overlay" initial={{ opacity: 1 }} animate={controls}>
+      <motion.span className="number-mask text-[20vw] sm:text-[15vw]">
+        2025
+      </motion.span>
+    </motion.div>
+  );
+};
+
+export default NumericZoomIntro;

--- a/src/index.css
+++ b/src/index.css
@@ -528,3 +528,23 @@ html {
   color: #ffffff;
   font-weight: bold;
 }
+
+/* Numeric Zoom Intro */
+.numeric-zoom-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: #0a1128;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10000;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.number-mask {
+  color: #ffffff;
+  font-weight: 900;
+  line-height: 0.8;
+  mix-blend-mode: destination-out;
+}


### PR DESCRIPTION
## Summary
- implement numeric zoom intro overlay
- import new overlay in main app
- mark ioredis mocking lines to satisfy ESLint

## Testing
- `npm run lint` *(fails: ESLint found too many warnings)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877381f7a2c8323bfd0fa762688f22c