### PR TITLE
Add DonateSection with payment options

### DIFF
--- a/src/components/common/DonateSection.tsx
+++ b/src/components/common/DonateSection.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { CreditCard, Banknote, DollarSign, Send } from 'lucide-react';
+import { useLanguage } from '../../contexts/LanguageContext';
+
+const DonateSection: React.FC = () => {
+  const { t, currentLanguage } = useLanguage();
+
+  const blurb = t(
+    'donate-blurb',
+    'We build resilient communities by connecting people, fostering innovation, and creating pathways for meaningful change. With your partnership, we can make a direct impact on those often excluded, whether recovering from conflict, marginalized due to their identity, or fighting for cultural recognition. Your support brings programs to life that honor cultural heritage, open economic doors, and deliver real, lasting change. Together, we create enduring connections that empower people to shape their own futures and transform their communities from the inside out.',
+    'We build resilient communities by connecting people, fostering innovation, and creating pathways for meaningful change. With your partnership, we can make a direct impact on those often excluded, whether recovering from conflict, marginalized due to their identity, or fighting for cultural recognition. Your support brings programs to life that honor cultural heritage, open economic doors, and deliver real, lasting change. Together, we create enduring connections that empower people to shape their own futures and transform their communities from the inside out.'
+  );
+
+  const methods = [
+    { icon: DollarSign, label: 'PayPal' },
+    { icon: Banknote, label: 'eTransfer' },
+    { icon: Send, label: 'Wise' },
+    { icon: Send, label: 'Google Pay' },
+    { icon: CreditCard, label: 'Credit / Debit' }
+  ];
+
+  return (
+    <section className="py-20 bg-gradient-to-br from-emerald-50 to-stone-50">
+      <div className="max-w-5xl mx-auto px-4 text-center">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className={`text-4xl font-bold mb-6 ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}
+        >
+          {t('donate-title', 'Support Our Work', 'ادعم عملنا')}
+        </motion.h2>
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className={`text-lg text-stone-700 leading-relaxed max-w-3xl mx-auto ${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}
+        >
+          {blurb}
+        </motion.p>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+          className="mt-8 flex flex-wrap justify-center gap-6"
+        >
+          {methods.map(({ icon: Icon, label }) => (
+            <button
+              key={label}
+              className="flex items-center gap-2 px-5 py-3 bg-emerald-600 text-white rounded-lg shadow hover:bg-emerald-700 transition"
+            >
+              <Icon className="w-5 h-5" />
+              {label}
+            </button>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default DonateSection;

--- a/src/components/home/NumberZoomIntro.tsx
+++ b/src/components/home/NumberZoomIntro.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { motion, AnimatePresence, useAnimation } from 'framer-motion';
+
+const NumberZoomIntro: React.FC = () => {
+  const [progress, setProgress] = useState(0);
+  const [visible, setVisible] = useState(true);
+  const controls = useAnimation();
+
+  useEffect(() => {
+    controls.start({
+      scale: 20,
+      filter: 'blur(12px)',
+      transition: { duration: 6, ease: [0.22, 1, 0.36, 1] }
+    });
+
+    const start = Date.now();
+    const duration = 6000;
+
+    const step = () => {
+      const elapsed = Date.now() - start;
+      const value = Math.min(100, Math.floor((elapsed / duration) * 100));
+      setProgress(value);
+      if (value < 100) {
+        requestAnimationFrame(step);
+      } else {
+        setTimeout(() => setVisible(false), 1000);
+      }
+    };
+
+    requestAnimationFrame(step);
+  }, [controls]);
+
+  const cutout = progress >= 70;
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          className="fixed inset-0 flex items-center justify-center bg-black z-50 pointer-events-none overflow-hidden"
+          initial={{ opacity: 1 }}
+          animate={{ opacity: 0 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 1, delay: 6, ease: 'easeInOut' }}
+        >
+          {!cutout && (
+            <motion.h1
+              animate={controls}
+              className="text-white font-extrabold leading-none"
+              style={{ fontSize: '20vw' }}
+            >
+              {progress}
+            </motion.h1>
+          )}
+          {cutout && (
+            <svg className="absolute inset-0 w-full h-full">
+              <defs>
+                <mask id="number-mask">
+                  <rect width="100%" height="100%" fill="white" />
+                  <motion.text
+                    x="50%"
+                    y="50%"
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fill="black"
+                    style={{ fontSize: '20vw' }}
+                    animate={controls}
+                  >
+                    {progress}
+                  </motion.text>
+                </mask>
+              </defs>
+              <rect width="100%" height="100%" fill="black" mask="url(#number-mask)" />
+            </svg>
+          )}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default NumberZoomIntro;

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { MapPin, Users, Target, Award, Calendar, Globe, Handshake } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
+import DonateSection from '../components/common/DonateSection';
 
 const AboutPage: React.FC = () => {
   const { t, currentLanguage } = useLanguage();
@@ -525,6 +526,7 @@ const AboutPage: React.FC = () => {
           </div>
         </div>
       </section>
+      <DonateSection />
     </div>
   );
 };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,19 +1,23 @@
 import React from 'react';
 import HeroSection from '../components/home/HeroSection';
+import NumberZoomIntro from '../components/home/NumberZoomIntro';
 import AboutPreview from '../components/home/AboutPreview';
 import ProgramsPreview from '../components/home/ProgramsPreview';
 import CommunityPreview from '../components/home/CommunityPreview';
 import InteractiveMap from '../components/home/InteractiveMap';
 import SentryTestButton from '../components/common/SentryTestButton';
+import DonateSection from '../components/common/DonateSection';
 
 const HomePage: React.FC = () => {
   return (
     <div>
+      <NumberZoomIntro />
       <HeroSection />
       <AboutPreview />
       <ProgramsPreview />
       <InteractiveMap />
       <CommunityPreview />
+      <DonateSection />
       <SentryTestButton />
     </div>
   );

--- a/src/pages/RhizomeSyriaPage.tsx
+++ b/src/pages/RhizomeSyriaPage.tsx
@@ -4,6 +4,7 @@ import { MapPin, Users, Target, Award, Calendar, Globe, Image, Palette, Heart, S
 import { useLanguage } from '../contexts/LanguageContext';
 import SyrianCitiesMap from '../components/common/SyrianCitiesMap';
 import VolunteerForms from '../components/common/VolunteerForms';
+import DonateSection from '../components/common/DonateSection';
 
 const RhizomeSyriaPage: React.FC = () => {
   const { t, currentLanguage } = useLanguage();
@@ -553,6 +554,7 @@ const RhizomeSyriaPage: React.FC = () => {
           <VolunteerForms />
         </div>
       </section>
+      <DonateSection />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create `DonateSection` component with PayPal, eTransfer, Wise, Google Pay, credit/debit options
- embed donation section in Home, Rhizome Syria, and About pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877381f7a2c8323bfd0fa762688f22c