### PR TITLE
Fix lint errors and update imports

### DIFF
--- a/server/__tests__/events.routes.test.ts
+++ b/server/__tests__/events.routes.test.ts
@@ -6,7 +6,7 @@ import eventRoutes from '../routes/events';
 import { EventCache } from '../db/cache';
 import Redis from 'ioredis';
 
-jest.mock('ioredis', () => require('ioredis-mock'));
+jest.mock('ioredis', () => jest.requireActual('ioredis-mock'));
 
 describe('Events API integration', () => {
   let app: express.Express;

--- a/server/db/cache.ts
+++ b/server/db/cache.ts
@@ -1,8 +1,9 @@
 import Redis from 'ioredis';
+import MockRedis from 'ioredis-mock';
 
 // Use in-memory Redis mock when running tests to avoid external dependency
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const MockRedis = process.env.NODE_ENV === 'test' ? require('ioredis-mock') : null;
+
+const RedisMock = process.env.NODE_ENV === 'test' ? MockRedis : null;
 import { Event } from '../types/event';
 
 export class EventCache {
@@ -10,7 +11,7 @@ export class EventCache {
   private TTL = 3600; // 1 hour
 
   constructor() {
-    const RedisClient = (process.env.NODE_ENV === 'test' && MockRedis) || Redis;
+    const RedisClient = (process.env.NODE_ENV === 'test' && RedisMock) || Redis;
     this.redis = new RedisClient({
       host: process.env.REDIS_HOST || 'localhost',
       port: parseInt(process.env.REDIS_PORT || '6379'),

--- a/server/index.ts
+++ b/server/index.ts
@@ -39,7 +39,7 @@ app.use('/api/events', eventRoutes);
 app.use('/api/health', healthRoutes);
 
 app.use(
-  (err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  (err: Error, _req: express.Request, res: express.Response) => {
     logger.error('Unhandled error:', err);
     res.status(500).json({
       error: 'Internal server error',

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -55,7 +55,7 @@ const HeroSection: React.FC = () => {
     }
 
     // Create more organic connections
-    nodes.forEach((node, i) => {
+    nodes.forEach((node, _i) => {
       const nearbyNodes = nodes
         .map((otherNode, j) => ({
           index: j,
@@ -63,7 +63,7 @@ const HeroSection: React.FC = () => {
             Math.pow(node.x - otherNode.x, 2) + Math.pow(node.y - otherNode.y, 2)
           ),
         }))
-        .filter((item) => item.index !== i && item.distance < 180)
+        .filter((item) => item.index !== _i && item.distance < 180)
         .sort((a, b) => a.distance - b.distance)
         .slice(0, Math.floor(Math.random() * 4) + 2);
 
@@ -95,7 +95,7 @@ const HeroSection: React.FC = () => {
       });
 
       // Draw connections with varied thickness and opacity
-      nodes.forEach((node, i) => {
+      nodes.forEach((node, _i) => {
         node.connections.forEach((connectionIndex) => {
           const connectedNode = nodes[connectionIndex];
           const distance = Math.sqrt(


### PR DESCRIPTION
## Summary
- replace `require` imports with ES modules in server cache and tests
- remove unused eslint-disable directive
- prefix unused loop index parameter in HeroSection
- remove unused `next` argument from express error handler

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint found too many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68777e8bf64c8323a4b79831024521d7