### PR TITLE
Fix imports and adjust test mocks

### DIFF
--- a/server/__tests__/events.routes.test.ts
+++ b/server/__tests__/events.routes.test.ts
@@ -6,7 +6,10 @@ import eventRoutes from '../routes/events';
 import { EventCache } from '../db/cache';
 import Redis from 'ioredis';
 
-jest.mock('ioredis', () => require('ioredis-mock'));
+jest.mock('ioredis', () => {
+  const mod = jest.requireActual('ioredis-mock');
+  return mod;
+});
 
 describe('Events API integration', () => {
   let app: express.Express;

--- a/server/db/cache.ts
+++ b/server/db/cache.ts
@@ -1,8 +1,8 @@
 import Redis from 'ioredis';
+import RedisMock from 'ioredis-mock';
 
 // Use in-memory Redis mock when running tests to avoid external dependency
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const MockRedis = process.env.NODE_ENV === 'test' ? require('ioredis-mock') : null;
+const MockRedis = process.env.NODE_ENV === 'test' ? RedisMock : null;
 import { Event } from '../types/event';
 
 export class EventCache {

--- a/server/index.ts
+++ b/server/index.ts
@@ -38,15 +38,19 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use('/api/events', eventRoutes);
 app.use('/api/health', healthRoutes);
 
-app.use(
-  (err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+const errorHandler: express.ErrorRequestHandler = (
+  err: Error,
+  _req: express.Request,
+  res: express.Response
+) => {
     logger.error('Unhandled error:', err);
     res.status(500).json({
       error: 'Internal server error',
       message: process.env.NODE_ENV === 'development' ? err.message : undefined
     });
-  }
-);
+  };
+
+app.use(errorHandler);
 
 process.on('SIGTERM', () => {
   logger.info('SIGTERM signal received: closing HTTP server');

--- a/server/scrapers/base.scraper.ts
+++ b/server/scrapers/base.scraper.ts
@@ -5,6 +5,7 @@ import { Event } from '../types/event';
 export abstract class BaseScraper {
   protected httpClient = createHttpClient();
 
+  // eslint-disable-next-line no-unused-vars
   abstract scrape(_url: string): Promise<Event[]>;
 
   protected async fetchPage(url: string): Promise<string | null> {

--- a/src/components/home/CommunityCarousel.tsx
+++ b/src/components/home/CommunityCarousel.tsx
@@ -242,7 +242,7 @@ const CommunityCarousel: React.FC = () => {
                             
                             {member.social && (
                               <div className="flex space-x-3 pt-2">
-                                {Object.entries(member.social).map(([platform, _handle]) => (
+                                {Object.entries(member.social).map(([platform]) => (
                                   <MagneticHover key={platform} strength={0.3}>
                                     <motion.button
                                       whileHover={{ scale: 1.2, rotate: 10 }}

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -95,7 +95,7 @@ const HeroSection: React.FC = () => {
       });
 
       // Draw connections with varied thickness and opacity
-      nodes.forEach((node, i) => {
+      nodes.forEach((node) => {
         node.connections.forEach((connectionIndex) => {
           const connectedNode = nodes[connectionIndex];
           const distance = Math.sqrt(

--- a/src/components/home/InteractiveMap.tsx
+++ b/src/components/home/InteractiveMap.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { MapPin, Calendar } from 'lucide-react';
 import { useLanguage } from '../../contexts/LanguageContext';
@@ -19,7 +19,7 @@ const InteractiveMap: React.FC = () => {
   const [selectedItem, setSelectedItem] = useState<MapItem | null>(null);
   const { t, currentLanguage } = useLanguage();
 
-  const cities: MapItem[] = [
+  const cities: MapItem[] = useMemo(() => [
     {
       id: 'latakia',
       lat: 35.5311,
@@ -74,9 +74,9 @@ const InteractiveMap: React.FC = () => {
       description: 'Mini TV, Dopamine',
       descriptionAr: 'ميني تي في، دوبامين'
     }
-  ];
+  ], []);
 
-  const events: MapItem[] = [
+  const events: MapItem[] = useMemo(() => [
     {
       id: 'rural-engagement',
       lat: 35.5311,
@@ -106,9 +106,9 @@ const InteractiveMap: React.FC = () => {
       descriptionAr: 'فعالية عيد القلعة - 10 حزيران 2025',
       date: '2025-06-10'
     }
-  ];
+  ], []);
 
-  const towns: { id: string; lat: number; lng: number }[] = [
+  const towns: { id: string; lat: number; lng: number }[] = useMemo(() => [
     { id: 'qanjarah', lat: 35.627, lng: 35.915 },
     { id: 'jannata', lat: 35.63, lng: 35.92 },
     { id: 'kirsana', lat: 35.58, lng: 35.95 },
@@ -133,9 +133,9 @@ const InteractiveMap: React.FC = () => {
     { id: 'sqilbieh', lat: 35.37, lng: 36.39 },
     { id: 'sheikhbadr', lat: 34.96, lng: 36.05 },
     { id: 'khreibat', lat: 34.9, lng: 35.97 }
-  ];
+  ], []);
 
-  const globalNodes: MapItem[] = [
+  const globalNodes: MapItem[] = useMemo(() => [
     {
       id: 'edmonton',
       lat: 53.5461,
@@ -145,7 +145,7 @@ const InteractiveMap: React.FC = () => {
       description: 'CO*LAB, RE:VITA, HQ',
       descriptionAr: 'CO*LAB، RE:VITA، المقر'
     }
-  ];
+  ], []);
 
   useEffect(() => {
     // Initialize Leaflet map
@@ -190,13 +190,13 @@ const InteractiveMap: React.FC = () => {
         });
 
         cities.forEach(item => {
-          const marker = L.marker([item.lat, item.lng], { icon: customIcon })
+          L.marker([item.lat, item.lng], { icon: customIcon })
             .addTo(map)
             .on('click', () => setSelectedItem(item));
         });
 
         events.forEach(item => {
-          const marker = L.marker([item.lat, item.lng], { icon: eventIcon })
+          L.marker([item.lat, item.lng], { icon: eventIcon })
             .addTo(map)
             .on('click', () => setSelectedItem(item));
         });
@@ -238,7 +238,7 @@ const InteractiveMap: React.FC = () => {
         };
       }
     }
-  }, []);
+  }, [cities, events, globalNodes, towns]);
 
   return (
     <section className="py-16 bg-white">

--- a/src/components/home/RhizomaticIntro.tsx
+++ b/src/components/home/RhizomaticIntro.tsx
@@ -98,7 +98,7 @@ const RhizomaticIntro: React.FC = () => {
       // Draw enhanced connections
       ctx.strokeStyle = 'rgba(16, 185, 129, 0.4)';
       ctx.lineWidth = 1.5;
-      nodes.forEach((node, i) => {
+      nodes.forEach((node) => {
         node.connections.forEach((connectionIndex) => {
           const connectedNode = nodes[connectionIndex];
           const distance = Math.sqrt(

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { Network, Mail, Phone, MapPin } from 'lucide-react';
+import { Network, Mail, MapPin } from 'lucide-react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { Link } from 'react-router-dom';
 

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -6,7 +6,8 @@ import { Menu, X, Globe, ChevronDown } from 'lucide-react';
 // Logo image sourced from the public folder. This image was provided in the
 // repository and represents the Rhizome branding colors.
 import LogoImage from '/20250710_0555_Rhizome Logo Design_remix_01jzt2tem6e8zse9br715pa28n (2).png';
-import { useLanguage, languages } from '../../contexts/LanguageContext';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { languages } from '../../data/languages';
 
 const Navigation: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,10 +1,6 @@
+/* eslint-disable no-unused-vars */
 import React, { createContext, useContext, useState, ReactNode } from 'react';
-
-interface Language {
-  code: 'en' | 'ar';
-  name: string;
-  direction: 'ltr' | 'rtl';
-}
+import { languages, Language } from '../data/languages';
 
 interface LanguageContextType {
   currentLanguage: Language;
@@ -12,13 +8,10 @@ interface LanguageContextType {
   t: (key: string, enText: string, arText: string) => string;
 }
 
-const languages: Language[] = [
-  { code: 'en', name: 'English', direction: 'ltr' },
-  { code: 'ar', name: 'العربية', direction: 'rtl' },
-];
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useLanguage = () => {
   const context = useContext(LanguageContext);
   if (!context) {
@@ -50,5 +43,3 @@ export const LanguageProvider: React.FC<LanguageProviderProps> = ({ children }) 
     </LanguageContext.Provider>
   );
 };
-
-export { languages };

--- a/src/contexts/PhotoContext.tsx
+++ b/src/contexts/PhotoContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React, { createContext, useContext, useState, ReactNode, useMemo } from 'react';
 import { photoList } from '../data/photoList';
 
@@ -39,6 +40,7 @@ interface PhotoContextType {
 
 const PhotoContext = createContext<PhotoContextType | undefined>(undefined);
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const usePhoto = () => {
   const context = useContext(PhotoContext);
   if (!context) {

--- a/src/data/languages.ts
+++ b/src/data/languages.ts
@@ -1,0 +1,10 @@
+export interface Language {
+  code: 'en' | 'ar';
+  name: string;
+  direction: 'ltr' | 'rtl';
+}
+
+export const languages: Language[] = [
+  { code: 'en', name: 'English', direction: 'ltr' },
+  { code: 'ar', name: 'العربية', direction: 'rtl' },
+];


### PR DESCRIPTION
## Summary
- replace CommonJS `require` calls with `import`
- clean up error handling middleware
- use memoized data arrays in `InteractiveMap`
- silence React-refresh lint rules on hooks/contexts
- export languages from new data file
- remove unused variables and imports

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint found too many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68777e8bf64c8323a4b79831024521d7