### PR TITLE
Fix low contrast text

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,7 @@
 :root {
   --primary-color: #4338ca; /* indigo */
   --secondary-color: #06b6d4; /* cyan */
-  --accent-color: #f59e0b; /* amber */
+  --accent-color: #b45309; /* dark amber for better contrast */
   --text-color: #1e293b; /* slate */
   --bg-color: #f5f3ff; /* violet */
   --card-bg: #ffffff;

--- a/src/knowledge-hub/rhizomatic-organization.html
+++ b/src/knowledge-hub/rhizomatic-organization.html
@@ -200,7 +200,7 @@
         }
 
         .traditional {
-            color: #999;
+            color: #666; /* darkened for better contrast */
         }
 
         .rhizomatic {


### PR DESCRIPTION
## Summary
- increase accent color contrast
- darken gray text in knowledge hub for readability

## Testing
- `npm test`
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68777de2cf38832383e3499b9ac3da29