### PR TITLE
Add quantum-inspired reveal effect

### DIFF
--- a/src/components/common/QuantumReveal.tsx
+++ b/src/components/common/QuantumReveal.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+interface QuantumRevealProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const QuantumReveal: React.FC<QuantumRevealProps> = ({ children, className = '' }) => {
+  const [revealed, setRevealed] = useState(false);
+
+  const handleMouseMove = () => {
+    if (!revealed && Math.random() < 0.1) {
+      setRevealed(true);
+      setTimeout(() => setRevealed(false), 2000);
+    }
+  };
+
+  const handleClick = () => setRevealed((r) => !r);
+
+  return (
+    <div
+      onMouseMove={handleMouseMove}
+      onClick={handleClick}
+      className={`${revealed ? 'quantum-revealed' : 'quantum-cloud'} ${className}`}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default QuantumReveal;

--- a/src/components/home/AboutPreview.tsx
+++ b/src/components/home/AboutPreview.tsx
@@ -2,12 +2,14 @@ import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
 import { useLanguage } from '../../contexts/LanguageContext';
+import QuantumReveal from '../common/QuantumReveal';
 
 const AboutPreview: React.FC = () => {
   const { t, currentLanguage } = useLanguage();
 
   return (
-    <section className="py-20 bg-white">
+    <QuantumReveal>
+      <section className="py-20 bg-white">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid lg:grid-cols-2 gap-12 items-center">
           {/* Visual - New Aleppo aerial shot */}
@@ -69,7 +71,8 @@ const AboutPreview: React.FC = () => {
           </motion.div>
         </div>
       </div>
-    </section>
+      </section>
+    </QuantumReveal>
   );
 };
 export default AboutPreview;

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,10 @@
   --border-radius: 12px;
   --shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 10px 40px rgba(0, 0, 0, 0.12);
+  --quantum-teal: #10B2A3;
+  --probability-purple: #8338EC;
+  --particle-gold: #FFD700;
+  --uncertainty-gray: #ACBDBA;
 }
 
 /* Cursor Styles - Fixed sizes */
@@ -527,4 +531,25 @@ html {
   font-size: 5rem;
   color: #ffffff;
   font-weight: bold;
+}
+
+/* Quantum Reveal Styles */
+.quantum-cloud {
+  filter: blur(20px);
+  opacity: 0.7;
+  transition: filter 0.4s ease, opacity 0.4s ease;
+  background: linear-gradient(60deg, var(--quantum-teal), var(--probability-purple), var(--particle-gold));
+  background-size: 200% 200%;
+  animation: quantumShift 6s ease infinite;
+}
+
+.quantum-revealed {
+  filter: blur(0);
+  opacity: 1;
+}
+
+@keyframes quantumShift {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
 }


### PR DESCRIPTION
## Summary
- create a `QuantumReveal` component for blurred elements that reveal on interaction
- define color variables for Quantum Teal, Probability Purple, Particle Gold and Uncertainty Gray
- add CSS for quantum reveal animations
- wrap `AboutPreview` section with `QuantumReveal`

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687c7c173a2c8323a89c8ff0eb28f04b