### PR TITLE
Implement chrono-sensitive theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,14 +18,16 @@ import KnowledgeHubPage from './pages/KnowledgeHubPage';
 import ParticleSystem from './components/common/ParticleSystem';
 import CustomCursor from './components/common/CustomCursor';
 import LoadingScreen from './components/common/LoadingScreen';
+import { useChronoTheme } from './hooks/useChronoTheme';
 
 function App() {
+  useChronoTheme();
   return (
     <LanguageProvider>
       <UserProvider>
         <PhotoProvider>
           <Router>
-          <div className="min-h-screen bg-gradient-to-br from-stone-50 to-emerald-50">
+          <div className="min-h-screen">
             <LoadingScreen />
             <CustomCursor />
             <Navigation />

--- a/src/hooks/useChronoTheme.ts
+++ b/src/hooks/useChronoTheme.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+
+const dayPalette = {
+  bg: '#CCF1FF',
+  gradientStart: '#CCF1FF',
+  gradientEnd: '#E4FFC7',
+  primary: '#E4FFC7',
+  accent: '#FFDAB9',
+  text: '#0A1031',
+};
+
+const nightPalette = {
+  bg: '#0A1031',
+  gradientStart: '#0A1031',
+  gradientEnd: '#3AAFA9',
+  primary: '#3AAFA9',
+  accent: '#D4D8E3',
+  text: '#D4D8E3',
+};
+
+export const useChronoTheme = () => {
+  useEffect(() => {
+    const root = document.documentElement;
+
+    const applyPalette = (palette: typeof dayPalette) => {
+      root.style.setProperty('--bg-color', palette.bg);
+      root.style.setProperty('--gradient-start', palette.gradientStart);
+      root.style.setProperty('--gradient-end', palette.gradientEnd);
+      root.style.setProperty('--primary-color', palette.primary);
+      root.style.setProperty('--accent-color', palette.accent);
+      root.style.setProperty('--text-color', palette.text);
+    };
+
+    const updateTheme = () => {
+      const hour = new Date().getHours();
+      if (hour >= 6 && hour < 18) {
+        applyPalette(dayPalette);
+      } else {
+        applyPalette(nightPalette);
+      }
+    };
+
+    updateTheme();
+    const interval = setInterval(updateTheme, 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+};

--- a/src/index.css
+++ b/src/index.css
@@ -78,13 +78,14 @@ body {
   margin: 0;
   padding: 0;
   background-color: var(--bg-color);
+  background-image: linear-gradient(to bottom right, var(--gradient-start, var(--bg-color)), var(--gradient-end, var(--bg-color)));
   color: var(--text-color);
   line-height: 1.6;
   overflow-x: hidden;
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, background-image 0.3s ease;
 }
 
 /* Custom selection colors */


### PR DESCRIPTION
## Summary
- add chrono theme hook with day/night palettes
- update global styles to support gradient background
- integrate chrono theme hook in main app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c5cbecc088323a79530794cb0e14e