### PR TITLE
Add quantum-inspired UI interactions

### DIFF
--- a/src/components/common/ProbabilityCloud.tsx
+++ b/src/components/common/ProbabilityCloud.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Link } from 'react-router-dom';
+
+interface ProbabilityCloudProps {
+  to: string;
+  children: React.ReactNode;
+}
+
+const ProbabilityCloud: React.FC<ProbabilityCloudProps> = ({ to, children }) => {
+  return (
+    <motion.div
+      className="probability-cloud quantum-gradient"
+      initial={{ filter: 'blur(8px)' }}
+      whileHover={{ filter: 'blur(0px)', scale: 1.05 }}
+      transition={{ duration: 0.4 }}
+    >
+      <Link
+        to={to}
+        className="probability-cloud-content block px-6 py-3 text-white font-semibold flex items-center gap-2"
+      >
+        {children}
+      </Link>
+    </motion.div>
+  );
+};
+
+export default ProbabilityCloud;

--- a/src/components/home/AboutPreview.tsx
+++ b/src/components/home/AboutPreview.tsx
@@ -1,7 +1,7 @@
 import { motion } from 'framer-motion';
-import { Link } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
 import { useLanguage } from '../../contexts/LanguageContext';
+import ProbabilityCloud from '../common/ProbabilityCloud';
 
 const AboutPreview: React.FC = () => {
   const { t, currentLanguage } = useLanguage();
@@ -50,22 +50,16 @@ const AboutPreview: React.FC = () => {
             </p>
 
 
-            <Link
-              to="/about"
-              className="group inline-flex items-center px-6 py-3 bg-emerald-600 text-white font-semibold rounded-lg hover:bg-emerald-700 transition-all duration-300 transform hover:scale-105"
-            >
-              <span className="mr-2">
-                {t('learn-more', 'Explore Our Story', 'اكتشف قصتنا')}
-              </span>
-              <ArrowRight className="h-5 w-5 group-hover:translate-x-1 transition-transform" />
-            </Link>
+            <ProbabilityCloud to="/about">
+              <span>{t('learn-more', 'Explore Our Story', 'اكتشف قصتنا')}</span>
+              <ArrowRight className="h-5 w-5" />
+            </ProbabilityCloud>
 
-            <Link
-              to="/knowledge-hub"
-              className="mt-4 inline-flex items-center px-6 py-3 bg-stone-200 text-stone-800 font-semibold rounded-lg hover:bg-stone-300 transition-all duration-300"
-            >
-              {t('browse-knowledge-hub', 'Browse Knowledge Hub', 'تصفح مركز المعرفة')}
-            </Link>
+            <div className="mt-4">
+              <ProbabilityCloud to="/knowledge-hub">
+                {t('browse-knowledge-hub', 'Browse Knowledge Hub', 'تصفح مركز المعرفة')}
+              </ProbabilityCloud>
+            </div>
           </motion.div>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -18,11 +18,11 @@
 
 /* Design System Variables */
 :root {
-  --primary-color: #4338ca; /* indigo */
-  --secondary-color: #06b6d4; /* cyan */
-  --accent-color: #b45309; /* dark amber for better contrast */
+  --primary-color: #10B2A3; /* Quantum Teal */
+  --secondary-color: #8338EC; /* Probability Purple */
+  --accent-color: #FFD700; /* Particle Gold */
   --text-color: #1e293b; /* slate */
-  --bg-color: #f5f3ff; /* violet */
+  --bg-color: #ACBDBA; /* Uncertainty Gray */
   --card-bg: #ffffff;
   --border-radius: 12px;
   --shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
@@ -527,4 +527,40 @@ html {
   font-size: 5rem;
   color: #ffffff;
   font-weight: bold;
+}
+
+/* Quantum Gradient Animation */
+.quantum-gradient {
+  background: linear-gradient(45deg, var(--primary-color), var(--secondary-color), var(--accent-color));
+  background-size: 200% 200%;
+  animation: quantumGradient 6s ease-in-out infinite;
+  border-radius: 9999px;
+}
+
+@keyframes quantumGradient {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+/* Probability Cloud */
+.probability-cloud {
+  display: inline-block;
+  pointer-events: auto;
+  transform: translateZ(0);
+  transition: filter 0.4s ease, transform 0.4s ease;
+  filter: blur(6px);
+}
+
+.probability-cloud:hover {
+  filter: blur(0);
+}
+
+.probability-cloud-content {
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.probability-cloud:hover .probability-cloud-content {
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary
- update global color palette to teal, purple, gold, and gray
- add quantum gradient animation and probability cloud styles
- implement `ProbabilityCloud` component
- use probability clouds on About preview

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint found too many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687c7c173a2c8323a89c8ff0eb28f04b