### PR TITLE
Improve events endpoint metadata

### DIFF
--- a/server/__tests__/events.api.test.ts
+++ b/server/__tests__/events.api.test.ts
@@ -32,6 +32,7 @@ describe('GET /api/events', () => {
   it('returns events from scraper when cache empty', async () => {
     const res = await request(app).get('/api/events');
     expect(res.status).toBe(200);
-    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body.events.length).toBeGreaterThan(0);
+    expect(res.body.metadata.totalEvents).toBe(res.body.events.length);
   });
 });

--- a/server/__tests__/events.routes.test.ts
+++ b/server/__tests__/events.routes.test.ts
@@ -47,7 +47,8 @@ describe('Events API integration', () => {
 
     const res = await request(app).get('/api/events');
     expect(res.status).toBe(200);
-    expect(res.body).toHaveLength(1);
-    expect(res.body[0].title).toBe('Community Meetup');
+    expect(res.body.events).toHaveLength(1);
+    expect(res.body.events[0].title).toBe('Community Meetup');
+    expect(res.body.metadata.totalEvents).toBe(1);
   });
 });

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -10,7 +10,15 @@ router.get('/', async (_req, res) => {
   if (!events || ttl <= 0) {
     events = await scrapeAndCache();
   }
-  res.json(events || []);
+
+  const metadata = {
+    totalEvents: events ? events.length : 0,
+    lastUpdated: new Date().toISOString(),
+    categories: events ? Array.from(new Set(events.map((e) => e.category))) : [],
+    sources: events ? Array.from(new Set(events.map((e) => e.source))) : [],
+  };
+
+  res.json({ events: events || [], metadata });
 });
 
 router.post('/', async (req, res) => {


### PR DESCRIPTION
## Summary
- return metadata from `/api/events`
- update events API tests to expect metadata
- keep integration tests in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687da48b72688323bc16f48b6846e4a2