### PR TITLE
Improve Syria map overlay and nav style

### DIFF
--- a/src/components/common/SyrianCitiesMap.tsx
+++ b/src/components/common/SyrianCitiesMap.tsx
@@ -21,11 +21,16 @@ const SyrianCitiesMap: React.FC = () => {
       .style('top', 0)
       .style('left', 0);
 
-    const projection = d3
-      .geoMercator()
-      .center([38.9968, 34.8021])
-      .scale(2500)
-      .translate([width / 2, height / 2]);
+    const latMin = 32.492;
+    const latMax = 37.17701;
+    const lngMin = 35.79011;
+    const lngMax = 42.14006;
+
+    const project = (lat: number, lng: number) => {
+      const x = ((lng - lngMin) / (lngMax - lngMin)) * width;
+      const y = height - ((lat - latMin) / (latMax - latMin)) * height;
+      return [x, y];
+    };
 
     const tooltip = d3
       .select(container)
@@ -44,8 +49,8 @@ const SyrianCitiesMap: React.FC = () => {
       .data(syrianCities)
       .enter()
       .append('circle')
-      .attr('cx', d => projection([d.lng, d.lat])[0])
-      .attr('cy', d => projection([d.lng, d.lat])[1])
+      .attr('cx', d => project(d.lat, d.lng)[0])
+      .attr('cy', d => project(d.lat, d.lng)[1])
       .attr('r', 2)
       .attr('fill', '#b91c1c')
       .on('mouseenter', (event, d) => {

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -49,8 +49,8 @@ const Navigation: React.FC = () => {
         animate={{ y: 0 }}
         className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
           isScrolled
-            ? 'bg-white/95 backdrop-blur-md shadow-lg'
-            : 'bg-transparent'
+            ? 'bg-white/40 backdrop-blur-lg border-b border-white/20 shadow-md'
+            : 'bg-white/10 backdrop-blur-lg'
         }`}
       >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- align Syria map markers with base map using manual lat/lon transform
- give navigation bar a glass-like style when scrolled

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68852fae48e08323a55707142dde3aad