### PR TITLE
Add hero logo animation

### DIFF
--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
 import { useLanguage } from '../../contexts/LanguageContext';
+import LogoImage from '/20250710_0555_Rhizome Logo Design_remix_01jzt2tem6e8zse9br715pa28n (2).png';
 
 const HeroSection: React.FC = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -211,6 +212,14 @@ const HeroSection: React.FC = () => {
           transition={{ duration: 1 }}
           className={`${currentLanguage.code === 'ar' ? 'font-arabic' : ''}`}
         >
+          <motion.img
+            src={LogoImage}
+            alt="Rhizome logo"
+            className="mx-auto mb-6 h-24 w-auto"
+            initial={{ opacity: 0, y: -20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 1 }}
+          />
           <motion.h1
             className="text-5xl md:text-7xl font-bold mb-6 text-white"
             initial={{ opacity: 0, scale: 0.8 }}


### PR DESCRIPTION
## Summary
- add Rhizome logo import in `HeroSection`
- animate the logo above the hero text on the landing page

## Testing
- `npm test --silent | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68877952724083239111885aa70f6d9e