### PR TITLE
Improve Syria page translations and banner colors

### DIFF
--- a/src/pages/RhizomeSyriaPage.tsx
+++ b/src/pages/RhizomeSyriaPage.tsx
@@ -65,14 +65,14 @@ const RhizomeSyriaPage: React.FC = () => {
 
   const methods = [
     { en: 'Open dialogue', ar: 'الحوار المفتوح' },
-    { en: 'Capacity building', ar: 'بناء القدرات' },
+    { en: 'Building capacity', ar: 'بناء القدرات' },
     { en: 'Local networking', ar: 'التشبيك المحلي' },
     { en: 'Economic reconciliation', ar: 'المصالحة الاقتصادية' },
-    { en: 'Independent financing', ar: 'التمويل المتسقل' },
+    { en: 'Independent funding', ar: 'التمويل المستقل' },
     { en: 'Dismantling hierarchy', ar: 'تفكيك الهرمية' },
     { en: 'Data analysis', ar: 'التحليل البياني' },
-    { en: 'Coordinating local resources and knowledge', ar: 'تنسيق المصادر والمعارف المحلية' },
-    { en: 'Sustainable healthy relations', ar: 'علاقات صحية مستديمة' },
+    { en: 'Coordination of local resources and knowledge', ar: 'تنسيق المصادر والمعارف المحلية' },
+    { en: 'Sustainable, healthy relationships', ar: 'علاقات صحية مستديمة' },
   ];
 
   const goals = [
@@ -541,7 +541,7 @@ const RhizomeSyriaPage: React.FC = () => {
 
       {/* Call to Action with Spiral Design */}
       <section className="rs-hero relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-r from-purple-600 via-blue-600 via-orange-400 to-red-500" />
+        <div className="absolute inset-0 bg-gradient-to-r from-teal-700 via-purple-700 to-amber-500" />
         <div className="absolute inset-0 opacity-20">
           <svg
             className="w-full h-full"

--- a/src/pages/RhizomeSyriaSubpage.tsx
+++ b/src/pages/RhizomeSyriaSubpage.tsx
@@ -50,7 +50,7 @@ const RhizomeSyriaSubpage: React.FC = () => {
     <div className="rhizome-syria min-h-screen bg-gradient-to-br from-purple-50 via-blue-50 to-orange-50">
       {/* Hero Section with Syrian Logo Integration */}
       <section className="rs-hero relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-r from-purple-600/90 via-blue-600/90 to-orange-600/90" />
+        <div className="absolute inset-0 bg-gradient-to-r from-teal-700/90 via-purple-700/90 to-amber-500/90" />
         <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
           <motion.div
             initial={{ opacity: 0, y: 30 }}
@@ -91,7 +91,7 @@ const RhizomeSyriaSubpage: React.FC = () => {
         </div>
         
         {/* Cultural Pattern Overlay */}
-        <div className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-r from-orange-500 via-red-500 to-purple-600 opacity-30" />
+        <div className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-r from-teal-700 via-purple-700 to-amber-500 opacity-30" />
       </section>
 
       {/* Programs Section */}
@@ -249,7 +249,7 @@ const RhizomeSyriaSubpage: React.FC = () => {
                     transition={{ duration: 0.6, delay: index * 0.1 }}
                     className="flex items-center"
                   >
-                    <div className="w-2 h-2 bg-gradient-to-r from-orange-500 to-red-500 rounded-full mr-3" />
+                    <div className="w-2 h-2 bg-gradient-to-r from-teal-700 to-amber-500 rounded-full mr-3" />
                     <span className={`rs-body ${currentLanguage.code === 'ar' ? 'rs-arabic' : ''}`}>
                       {t(`heritage-item-${index}`, item.label, item.labelAr)}
                     </span>

--- a/src/styles/rhizome-syria.css
+++ b/src/styles/rhizome-syria.css
@@ -27,6 +27,8 @@
   --rs-gradient-warm: linear-gradient(135deg, var(--rs-primary-orange), var(--rs-primary-red));
   --rs-gradient-cool: linear-gradient(135deg, var(--rs-primary-blue), var(--rs-teal));
   --rs-gradient-sunset: linear-gradient(135deg, var(--rs-primary-yellow), var(--rs-primary-orange), var(--rs-primary-red));
+  /* Fresh colors for the banner */
+  --rs-banner-gradient: linear-gradient(135deg, var(--rs-teal), var(--rs-primary-purple), var(--rs-amber));
   
   /* Typography */
   --rs-font-primary: 'Noto Sans Arabic', 'Poppins', sans-serif;
@@ -183,7 +185,7 @@
 }
 
 .rs-hero {
-  background: var(--rs-gradient-sunset);
+  background: var(--rs-banner-gradient);
   color: var(--rs-white);
   padding: var(--rs-space-3xl) 0;
   position: relative;


### PR DESCRIPTION
## Summary
- refine English translations for Rhizome Syria page
- add new banner gradient colors in `rhizome-syria.css`
- apply updated gradient to Syria page and subpage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688acb9b841c83238c0fe17fdae20064