### PR TITLE
Fix English copy and tweak Syria banner

### DIFF
--- a/src/pages/RhizomeSyriaPage.tsx
+++ b/src/pages/RhizomeSyriaPage.tsx
@@ -295,7 +295,7 @@ const RhizomeSyriaPage: React.FC = () => {
                   <p className="rs-body">
                     {t(
                       'mission-text-1',
-                      'The idea: Activate the latent power in communities through a decentralized horizontal network.',
+                      'Our idea is to unleash community potential through a decentralized, horizontal network.',
                       'الفكرة: تفعيل القوة الكامنة في المجتمعات عبر شبكة علاقات أفقية غير مركزية.'
                     )}
                   </p>
@@ -303,7 +303,7 @@ const RhizomeSyriaPage: React.FC = () => {
                   <p className="rs-body">
                     {t(
                       'mission-text-2',
-                      'The need: Syrian communities require a development model rooted in local realities.',
+                      'Syrian communities need a development model grounded in their own local realities.',
                       'الحاجة: حاجة المجتمعات السورية المتنوعة إلى نموذج تنموي من قلب الواقع المحلي.'
                     )}
                   </p>
@@ -348,7 +348,7 @@ const RhizomeSyriaPage: React.FC = () => {
                 >
                   {t(
                     'structure-text',
-                    'Strategic partnerships: broad local cooperation and a development partnership with the Rhizome Community Foundation in Canada ensure autonomy and coordination.',
+                    'Through wide local cooperation and a development partnership with the Rhizome Community Foundation in Canada, we ensure autonomy and coordinated efforts.',
                     'شراكات استراتيجية: شراكات محلية واسعة، وشراكة تنموية مع مؤسسة رايزوم المجتمعية كندا، لضمان الاستقلالية والتنسيق.'
                   )}
                 </p>

--- a/src/styles/rhizome-syria.css
+++ b/src/styles/rhizome-syria.css
@@ -26,7 +26,7 @@
   --rs-gradient-primary: linear-gradient(135deg, var(--rs-primary-purple), var(--rs-primary-blue));
   --rs-gradient-warm: linear-gradient(135deg, var(--rs-primary-orange), var(--rs-primary-red));
   --rs-gradient-cool: linear-gradient(135deg, var(--rs-primary-blue), var(--rs-teal));
-  --rs-gradient-sunset: linear-gradient(135deg, var(--rs-primary-yellow), var(--rs-primary-orange), var(--rs-primary-red));
+  --rs-gradient-sunset: linear-gradient(135deg, var(--rs-teal), var(--rs-primary-blue), var(--rs-primary-purple));
   
   /* Typography */
   --rs-font-primary: 'Noto Sans Arabic', 'Poppins', sans-serif;


### PR DESCRIPTION
## Summary
- refine English text on the Rhizome Syria page
- tweak banner gradient colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688acb9b841c83238c0fe17fdae20064