### PR TITLE
Remove heading text in Rhizome Syria hero

### DIFF
--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+} from 'react';
 /* eslint-disable react-refresh/only-export-components */
 
 interface Language {
@@ -33,13 +39,26 @@ interface LanguageProviderProps {
 }
 
 export const LanguageProvider: React.FC<LanguageProviderProps> = ({ children }) => {
-  const [currentLanguage, setCurrentLanguage] = useState<Language>(languages[0]);
+  const getInitialLanguage = (): Language => {
+    if (typeof window !== 'undefined') {
+      const { hostname, pathname } = window.location;
+      if (hostname.includes('rhizomsyria.org') || pathname.startsWith('/rhizome-syria')) {
+        return languages[1];
+      }
+    }
+    return languages[0];
+  };
+
+  const [currentLanguage, setCurrentLanguage] = useState<Language>(getInitialLanguage);
 
   const setLanguage = (language: Language) => {
     setCurrentLanguage(language);
-    document.documentElement.dir = language.direction;
-    document.documentElement.lang = language.code;
   };
+
+  useEffect(() => {
+    document.documentElement.dir = currentLanguage.direction;
+    document.documentElement.lang = currentLanguage.code;
+  }, [currentLanguage]);
 
   const t = (key: string, enText: string, arText: string): string => {
     return currentLanguage.code === 'ar' ? arText : enText;

--- a/src/pages/RhizomeSyriaPage.tsx
+++ b/src/pages/RhizomeSyriaPage.tsx
@@ -156,23 +156,17 @@ const RhizomeSyriaPage: React.FC = () => {
             transition={{ duration: 0.8 }}
             className={`text-center ${currentLanguage.code === 'ar' ? 'rs-arabic' : ''}`}
           >
-            {/* Logo Integration */}
-            <motion.div
+          {/* Logo Integration */}
+          <h1 className="rs-heading-1 mb-6 flex justify-center">
+            <motion.img
               initial={{ scale: 0.8, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
               transition={{ duration: 1, delay: 0.3 }}
-              className="flex justify-center mb-8"
-            >
-              <img
-                src="/20250629_1822_Gradient Logo Design_remix_01jyz38q10e56bpwt8s4ypzwhj.png"
-                alt="Rhizome Syria Logo"
-                className="h-64 md:h-80 w-auto drop-shadow-xl"
-              />
-            </motion.div>
-
-            <h1 className="rs-heading-1 mb-6">
-              {t('rhizome-syria-title', 'Rhizome Syria', 'رايزوم سوريا')}
-            </h1>
+              src="/20250629_1822_Gradient Logo Design_remix_01jyz38q10e56bpwt8s4ypzwhj.png"
+              alt="Rhizome Syria Logo"
+              className="h-64 md:h-80 w-auto drop-shadow-xl"
+            />
+          </h1>
 
             <motion.p
               initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
## Summary
- show the logo image in the hero area of the Rhizome Syria page
- drop the redundant textual title
- default the Rhizome Syria page to Arabic when accessed directly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688aeed1f5ac8323851ee231ef200700