### PR TITLE
Enhance Rhizome Syria hero and capture join requests

### DIFF
--- a/server/db/requests.json
+++ b/server/db/requests.json
@@ -1,0 +1,4 @@
+{
+  "volunteers": [],
+  "orgs": []
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,8 @@ import { swaggerSpec } from './swagger';
 import swaggerUi from 'swagger-ui-express';
 import eventRoutes from './routes/events';
 import healthRoutes from './routes/health';
+import volunteerRoutes from './routes/volunteer';
+import joinRoutes from './routes/join';
 import './jobs/scraper.job';
 import { scrapeAndCache } from './utils/scrape';
 
@@ -37,6 +39,8 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 app.use('/api/events', eventRoutes);
 app.use('/api/health', healthRoutes);
+app.use('/api/volunteer', volunteerRoutes);
+app.use('/api/join', joinRoutes);
 
 app.use(
   (err: Error, _req: express.Request, res: express.Response) => {

--- a/server/routes/join.ts
+++ b/server/routes/join.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { readData, writeData } from '../utils/storage';
+
+const router = Router();
+
+router.post('/', async (req: Request, res: Response) => {
+  const { org, contact, email, message } = req.body;
+  if (!org || !contact || !email) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+
+  const data = await readData();
+  data.orgs.push({ org, contact, email, message, date: new Date().toISOString() });
+  await writeData(data);
+  res.status(201).json({ success: true });
+});
+
+export default router;

--- a/server/routes/volunteer.ts
+++ b/server/routes/volunteer.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { readData, writeData } from '../utils/storage';
+
+const router = Router();
+
+router.post('/', async (req: Request, res: Response) => {
+  const { name, email, message } = req.body;
+  if (!name || !email) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+
+  const data = await readData();
+  data.volunteers.push({ name, email, message, date: new Date().toISOString() });
+  await writeData(data);
+  res.status(201).json({ success: true });
+});
+
+export default router;

--- a/server/utils/storage.ts
+++ b/server/utils/storage.ts
@@ -1,0 +1,22 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const DATA_FILE = path.join(__dirname, '../db/requests.json');
+
+interface RequestData {
+  volunteers: Array<Record<string, unknown>>;
+  orgs: Array<Record<string, unknown>>;
+}
+
+export async function readData(): Promise<RequestData> {
+  try {
+    const content = await fs.readFile(DATA_FILE, 'utf-8');
+    return JSON.parse(content) as RequestData;
+  } catch {
+    return { volunteers: [], orgs: [] };
+  }
+}
+
+export async function writeData(data: RequestData): Promise<void> {
+  await fs.writeFile(DATA_FILE, JSON.stringify(data, null, 2));
+}

--- a/src/components/common/OrgRegistrationForms.tsx
+++ b/src/components/common/OrgRegistrationForms.tsx
@@ -1,21 +1,39 @@
 import React from 'react';
 
 const OrgRegistrationForms: React.FC = () => {
-  const handleSubmit = () => {
-    alert('Thank you for registering!');
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const data = Object.fromEntries(formData.entries());
+
+    try {
+      const res = await fetch('/api/join', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+      });
+
+      if (res.ok) {
+        alert('Thank you for registering!');
+        form.reset();
+      } else {
+        alert('Submission failed. Please try again.');
+      }
+    } catch {
+      alert('Submission failed. Please try again.');
+    }
   };
 
   return (
     <div className="grid gap-8 md:grid-cols-2 mt-8">
       <form
-        id="org-registration-form-en"
-        name="org-registration-en"
         method="POST"
-        data-netlify="true"
         onSubmit={handleSubmit}
         className="space-y-4 bg-white p-6 rounded-xl shadow"
       >
-        <input type="hidden" name="form-name" value="org-registration-en" />
         <h3 className="text-xl font-bold text-emerald-700">
           Register Your Organization
         </h3>
@@ -53,15 +71,11 @@ const OrgRegistrationForms: React.FC = () => {
         </button>
       </form>
       <form
-        id="org-registration-form-ar"
-        name="org-registration-ar"
         method="POST"
-        data-netlify="true"
         dir="rtl"
         onSubmit={handleSubmit}
         className="space-y-4 bg-white p-6 rounded-xl shadow"
       >
-        <input type="hidden" name="form-name" value="org-registration-ar" />
         <h3 className="text-xl font-bold text-emerald-700">سجل منظمتك</h3>
         <input
           type="text"

--- a/src/components/common/VolunteerForms.tsx
+++ b/src/components/common/VolunteerForms.tsx
@@ -1,20 +1,39 @@
+import React from 'react';
 
 const VolunteerForms: React.FC = () => {
-  const handleSubmit = () => {
-    alert('Thank you for volunteering!');
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const data = Object.fromEntries(formData.entries());
+
+    try {
+      const res = await fetch('/api/volunteer', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+      });
+
+      if (res.ok) {
+        alert('Thank you for volunteering!');
+        form.reset();
+      } else {
+        alert('Submission failed. Please try again.');
+      }
+    } catch {
+      alert('Submission failed. Please try again.');
+    }
   };
 
   return (
     <div className="grid gap-8 md:grid-cols-2 mt-8">
       <form
-        id="rcf-volunteer-form"
-        name="rcf-volunteer"
         method="POST"
-        data-netlify="true"
         onSubmit={handleSubmit}
         className="space-y-4 bg-white p-6 rounded-xl shadow"
       >
-        <input type="hidden" name="form-name" value="rcf-volunteer" />
         <h3 className="text-xl font-bold text-emerald-700">Volunteer with RCF</h3>
         <input type="text" name="name" placeholder="Name" className="w-full border p-2 rounded" required />
         <input type="email" name="email" placeholder="Email" className="w-full border p-2 rounded" required />
@@ -22,15 +41,11 @@ const VolunteerForms: React.FC = () => {
         <button type="submit" className="px-4 py-2 bg-emerald-600 text-white rounded">Submit</button>
       </form>
       <form
-        id="rhizome-syria-form"
-        name="rhizome-syria-volunteer"
         method="POST"
-        data-netlify="true"
         dir="rtl"
         onSubmit={handleSubmit}
         className="space-y-4 bg-white p-6 rounded-xl shadow"
       >
-        <input type="hidden" name="form-name" value="rhizome-syria-volunteer" />
         <h3 className="text-xl font-bold text-emerald-700">تطوع مع رايزوم سوريا</h3>
         <input type="text" name="name" placeholder="الاسم" className="w-full border p-2 rounded text-right" required />
         <input type="email" name="email" placeholder="البريد الإلكتروني" className="w-full border p-2 rounded text-right" required />

--- a/src/pages/RhizomeSyriaPage.tsx
+++ b/src/pages/RhizomeSyriaPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import {
@@ -7,14 +8,35 @@ import {
   Heart,
   Shield,
   Sparkles,
+  CheckCircle,
 } from 'lucide-react';
-import { useLanguage } from '../contexts/LanguageContext';
+import { useLanguage, languages } from '../contexts/LanguageContext';
 import VolunteerForms from '../components/common/VolunteerForms';
 import FeaturedLeaders from '../components/community/FeaturedLeaders';
 import '../styles/rhizome-syria.css';
 
 const RhizomeSyriaPage: React.FC = () => {
-  const { t, currentLanguage } = useLanguage();
+  const { t, currentLanguage, setLanguage } = useLanguage();
+
+  useEffect(() => {
+    const host = window.location.hostname;
+    const path = window.location.pathname;
+    if (host.includes('rhizomsyria.org') || path.startsWith('/rhizome-syria')) {
+      const arabic = languages.find((l) => l.code === 'ar');
+      if (arabic) {
+        setLanguage(arabic);
+        document.documentElement.dir = 'rtl';
+        document.documentElement.lang = 'ar';
+      }
+    } else {
+      const english = languages.find((l) => l.code === 'en');
+      if (english) {
+        setLanguage(english);
+        document.documentElement.dir = 'ltr';
+        document.documentElement.lang = 'en';
+      }
+    }
+  }, [setLanguage]);
 
   const board = [
     {
@@ -156,29 +178,23 @@ const RhizomeSyriaPage: React.FC = () => {
             transition={{ duration: 0.8 }}
             className={`text-center ${currentLanguage.code === 'ar' ? 'rs-arabic' : ''}`}
           >
-            {/* Logo Integration */}
-            <motion.div
+          {/* Logo Integration */}
+          <h1 className="rs-heading-1 mb-6 flex justify-center">
+            <motion.img
               initial={{ scale: 0.8, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
               transition={{ duration: 1, delay: 0.3 }}
-              className="flex justify-center mb-8"
-            >
-              <img
-                src="/20250629_1822_Gradient Logo Design_remix_01jyz38q10e56bpwt8s4ypzwhj.png"
-                alt="Rhizome Syria Logo"
-                className="h-64 md:h-80 w-auto drop-shadow-xl"
-              />
-            </motion.div>
-
-            <h1 className="rs-heading-1 mb-6">
-              {t('rhizome-syria-title', 'Rhizome Syria', 'رايزوم سوريا')}
-            </h1>
+              src="/20250629_1822_Gradient Logo Design_remix_01jyz38q10e56bpwt8s4ypzwhj.png"
+              alt="Rhizome Syria Logo"
+              className="h-72 md:h-96 w-auto drop-shadow-xl"
+            />
+          </h1>
 
             <motion.p
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.7 }}
-              className="rs-body-large text-white/90 max-w-4xl mx-auto mb-8"
+              className={`text-3xl font-bold text-white max-w-4xl mx-auto mb-8 drop-shadow-lg ${currentLanguage.code === 'ar' ? 'rs-arabic' : ''}`}
             >
               {t(
                 'rhizome-syria-subtitle',
@@ -239,18 +255,34 @@ const RhizomeSyriaPage: React.FC = () => {
             <h3 className="rs-heading-3 mb-4">
               {t('methods-heading', 'Our Approach: How We Work', 'الوسائل')}
             </h3>
-            <ul className="list-disc pl-5 space-y-2 mb-6">
+            <ul className="grid sm:grid-cols-2 gap-4 mb-6">
               {methods.map((item, index) => (
-                <li key={index}>{t(`method-${index}`, item.en, item.ar)}</li>
+                <li
+                  key={index}
+                  className={`flex items-center gap-3 bg-white/70 backdrop-blur-sm p-3 rounded-lg shadow-sm ${currentLanguage.code === 'ar' ? 'rs-arabic flex-row-reverse' : ''}`}
+                >
+                  <div className="w-6 h-6 bg-gradient-to-br from-purple-500 to-blue-500 rounded-full flex items-center justify-center flex-shrink-0">
+                    <CheckCircle className="h-4 w-4 text-white" />
+                  </div>
+                  <span>{t(`method-${index}`, item.en, item.ar)}</span>
+                </li>
               ))}
             </ul>
 
             <h3 className="rs-heading-3 mb-4">
               {t('goals-heading', 'The Rhizome Philosophy', 'الأهداف')}
             </h3>
-            <ul className="list-disc pl-5 space-y-2 mb-6">
+            <ul className="grid sm:grid-cols-2 gap-4 mb-6">
               {goals.map((item, index) => (
-                <li key={index}>{t(`goal-${index}`, item.en, item.ar)}</li>
+                <li
+                  key={index}
+                  className={`flex items-center gap-3 bg-white/70 backdrop-blur-sm p-3 rounded-lg shadow-sm ${currentLanguage.code === 'ar' ? 'rs-arabic flex-row-reverse' : ''}`}
+                >
+                  <div className="w-6 h-6 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center flex-shrink-0">
+                    <CheckCircle className="h-4 w-4 text-white" />
+                  </div>
+                  <span>{t(`goal-${index}`, item.en, item.ar)}</span>
+                </li>
               ))}
             </ul>
 


### PR DESCRIPTION
## Summary
- grow the hero logo, highlight the "development by and for the grassroots" tagline and replace plain bullet lists with styled cards
- allow join and volunteer forms to submit to new API routes that store requests on the server

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688aeed1f5ac8323851ee231ef200700